### PR TITLE
Test code coverage reporting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,11 @@ jobs:
             - v1-dependencies-{{ checksum "package.json" }}
             # fallback to using the latest cache if no exact match is found
             - v1-dependencies-
-      - run: curl https://sh.rustup.rs -sSf | sh -s -- -y
-      - run: npm install
+      - run:
+          command: |
+            curl https://sh.rustup.rs -sSf | sh -s -- -y
+            source $HOME/.cargo/env
+            npm install
 
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,10 @@ jobs:
             - v1-dependencies-{{ checksum "package.json" }}
             # fallback to using the latest cache if no exact match is found
             - v1-dependencies-
-      - run: npm install
+      - run:
+          command: |
+            curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.34.0
+            npm install
 
       - save_cache:
           paths:
@@ -21,7 +24,6 @@ jobs:
 
       - run:
           command: |
-            curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.34.0
             source $HOME/.cargo/env
             npm run test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,16 +11,17 @@ jobs:
             - v1-dependencies-{{ checksum "package.json" }}
             # fallback to using the latest cache if no exact match is found
             - v1-dependencies-
-      - run:
-          command: |
-            curl https://sh.rustup.rs -sSf | sh -s -- -y
-            source $HOME/.cargo/env
-            npm install
+      - run: npm install
 
       - save_cache:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
 
-      - run: npm run test
+      - run:
+          command: |
+            curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.34.0
+            source $HOME/.cargo/env
+            npm run test
+
       - run: npm run codecov-upload

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
             - v1-dependencies-{{ checksum "package.json" }}
             # fallback to using the latest cache if no exact match is found
             - v1-dependencies-
-
+      - run: curl https://sh.rustup.rs -sSf | sh -s -- -y
       - run: npm install
 
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ jobs:
       - save_cache:
           paths:
             - node_modules
+            - "~/.cargo"
           key: v1-dependencies-{{ checksum "package.json" }}
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,23 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/node:10
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "package.json" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      - run: npm install
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+
+      - run: npm run test
+      - run: npm run codecov-upload

--- a/package-lock.json
+++ b/package-lock.json
@@ -1094,9 +1094,9 @@
       }
     },
     "@types/node": {
-      "version": "10.14.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.7.tgz",
-      "integrity": "sha512-on4MmIDgHXiuJDELPk1NFaKVUxxCFr37tm8E9yN6rAiF5Pzp/9bBfBHkoexqRiY+hk/Z04EJU9kKEb59YqJ82A==",
+      "version": "10.14.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.8.tgz",
+      "integrity": "sha512-I4+DbJEhLEg4/vIy/2gkWDvXBOOtPKV9EnLhYjMoqxcRW+TTZtUftkHktz/a8suoD5mUL7m6ReLrkPvSsCQQmw==",
       "dev": true
     },
     "JSONStream": {
@@ -1145,12 +1145,6 @@
         "uri-js": "^4.2.2"
       }
     },
-    "ansi-colors": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
-      "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
-      "dev": true
-    },
     "ansi-escapes": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
@@ -1196,6 +1190,12 @@
       "requires": {
         "sprintf-js": "~1.0.2"
       }
+    },
+    "argv": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/argv/-/argv-0.0.2.tgz",
+      "integrity": "sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas=",
+      "dev": true
     },
     "arr-diff": {
       "version": "4.0.0",
@@ -1437,12 +1437,6 @@
           }
         }
       }
-    },
-    "browser-stdout": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-      "dev": true
     },
     "btoa-lite": {
       "version": "1.0.0",
@@ -1698,6 +1692,19 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
+    },
+    "codecov": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.5.0.tgz",
+      "integrity": "sha512-/OsWOfIHaQIr7aeZ4pY0UC1PZT6kimoKFOFYFNb6wxo3iw12nRrh+mNGH72rnXxNsq6SGfesVPizm/6Q3XqcFQ==",
+      "dev": true,
+      "requires": {
+        "argv": "^0.0.2",
+        "ignore-walk": "^3.0.1",
+        "js-yaml": "^3.13.1",
+        "teeny-request": "^3.11.3",
+        "urlgrey": "^0.4.4"
+      }
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -2118,15 +2125,6 @@
         "clone": "^1.0.2"
       }
     },
-    "define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
-      "requires": {
-        "object-keys": "^1.0.12"
-      }
-    },
     "define-property": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
@@ -2202,12 +2200,6 @@
         "wrappy": "1"
       }
     },
-    "diff": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-      "dev": true
-    },
     "dir-glob": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
@@ -2255,12 +2247,6 @@
         "safer-buffer": "^2.1.0"
       }
     },
-    "emoji-regex": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-      "dev": true
-    },
     "encoding": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
@@ -2292,31 +2278,6 @@
       "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
-      }
-    },
-    "es-abstract": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
-      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
-      "dev": true,
-      "requires": {
-        "es-to-primitive": "^1.2.0",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "is-callable": "^1.1.4",
-        "is-regex": "^1.0.4",
-        "object-keys": "^1.0.12"
-      }
-    },
-    "es-to-primitive": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
-      "dev": true,
-      "requires": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
       }
     },
     "es6-promise": {
@@ -2604,23 +2565,6 @@
         "locate-path": "^2.0.0"
       }
     },
-    "flat": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
-      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
-      "dev": true,
-      "requires": {
-        "is-buffer": "~2.0.3"
-      },
-      "dependencies": {
-        "is-buffer": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
-          "dev": true
-        }
-      }
-    },
     "flush-write-stream": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
@@ -2698,12 +2642,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
-    },
-    "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
     "gauge": {
@@ -3052,12 +2990,6 @@
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
       "dev": true
     },
-    "growl": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-      "dev": true
-    },
     "handlebars": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
@@ -3094,25 +3026,10 @@
         "har-schema": "^2.0.0"
       }
     },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.1"
-      }
-    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
-    },
-    "has-symbols": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true
     },
     "has-unicode": {
@@ -3152,12 +3069,6 @@
           }
         }
       }
-    },
-    "he": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "dev": true
     },
     "hosted-git-info": {
       "version": "2.7.1",
@@ -3464,12 +3375,6 @@
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
-    "is-callable": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
-      "dev": true
-    },
     "is-ci": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
@@ -3498,12 +3403,6 @@
           }
         }
       }
-    },
-    "is-date-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-      "dev": true
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -3616,15 +3515,6 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
-    "is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true,
-      "requires": {
-        "has": "^1.0.1"
-      }
-    },
     "is-ssh": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.1.tgz",
@@ -3639,15 +3529,6 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
-    },
-    "is-symbol": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
-      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
-      "dev": true,
-      "requires": {
-        "has-symbols": "^1.0.0"
-      }
     },
     "is-text-path": {
       "version": "2.0.0",
@@ -3941,15 +3822,6 @@
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
     },
-    "log-symbols": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
-      "dev": true,
-      "requires": {
-        "chalk": "^2.0.1"
-      }
-    },
     "loud-rejection": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
@@ -4235,199 +4107,6 @@
         }
       }
     },
-    "mocha": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.1.4.tgz",
-      "integrity": "sha512-PN8CIy4RXsIoxoFJzS4QNnCH4psUCPWc4/rPrst/ecSJJbLBkubMiyGCP2Kj/9YnWbotFqAoeXyXMucj7gwCFg==",
-      "dev": true,
-      "requires": {
-        "ansi-colors": "3.2.3",
-        "browser-stdout": "1.3.1",
-        "debug": "3.2.6",
-        "diff": "3.5.0",
-        "escape-string-regexp": "1.0.5",
-        "find-up": "3.0.0",
-        "glob": "7.1.3",
-        "growl": "1.10.5",
-        "he": "1.2.0",
-        "js-yaml": "3.13.1",
-        "log-symbols": "2.2.0",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "ms": "2.1.1",
-        "node-environment-flags": "1.0.5",
-        "object.assign": "4.1.0",
-        "strip-json-comments": "2.0.1",
-        "supports-color": "6.0.0",
-        "which": "1.3.1",
-        "wide-align": "1.1.3",
-        "yargs": "13.2.2",
-        "yargs-parser": "13.0.0",
-        "yargs-unparser": "1.5.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-          "dev": true
-        },
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
-        },
-        "get-caller-file": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-          "dev": true
-        },
-        "glob": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-          "dev": true
-        },
-        "p-limit": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-          "dev": true
-        },
-        "require-main-filename": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        },
-        "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        },
-        "yargs": {
-          "version": "13.2.2",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.2.tgz",
-          "integrity": "sha512-WyEoxgyTD3w5XRpAQNYUB9ycVH/PQrToaTXdYXRdOXvEy1l19br+VJsc0vcO8PTGg5ro/l/GY7F/JMEBmI0BxA==",
-          "dev": true,
-          "requires": {
-            "cliui": "^4.0.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^2.0.1",
-            "os-locale": "^3.1.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^3.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^13.0.0"
-          }
-        },
-        "yargs-parser": {
-          "version": "13.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.0.0.tgz",
-          "integrity": "sha512-w2LXjoL8oRdRQN+hOyppuXs+V/fVAYtpcrRxZuF7Kt/Oc+Jr2uAcVntaUTNT6w5ihoWfFDpNY8CPx1QskxZ/pw==",
-          "dev": true,
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          }
-        }
-      }
-    },
     "modify-values": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
@@ -4502,16 +4181,6 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
-    },
-    "node-environment-flags": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
-      "integrity": "sha512-VNYPRfGfmZLx0Ye20jWzHUjyTW/c+6Wq+iLhDzUI4XmhrDd9l/FozXV3F2xOaXjvp0co0+v1YSR3CMP6g+VvLQ==",
-      "dev": true,
-      "requires": {
-        "object.getownpropertydescriptors": "^2.0.3",
-        "semver": "^5.7.0"
-      }
     },
     "node-fetch": {
       "version": "2.6.0",
@@ -4741,12 +4410,6 @@
         }
       }
     },
-    "object-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
-    },
     "object-visit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
@@ -4754,28 +4417,6 @@
       "dev": true,
       "requires": {
         "isobject": "^3.0.0"
-      }
-    },
-    "object.assign": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.0",
-        "object-keys": "^1.0.11"
-      }
-    },
-    "object.getownpropertydescriptors": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
-      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.5.1"
       }
     },
     "object.pick": {
@@ -5960,12 +5601,6 @@
       "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
       "dev": true
     },
-    "strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "dev": true
-    },
     "strong-log-transformer": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/strong-log-transformer/-/strong-log-transformer-2.1.0.tgz",
@@ -5999,6 +5634,17 @@
         "mkdirp": "^0.5.0",
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.2"
+      }
+    },
+    "teeny-request": {
+      "version": "3.11.3",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-3.11.3.tgz",
+      "integrity": "sha512-CKncqSF7sH6p4rzCgkb/z/Pcos5efl0DmolzvlqRQUNcpRIruOhY9+T1FsIlyEbfWd7MsFpodROOwHYh2BaXzw==",
+      "dev": true,
+      "requires": {
+        "https-proxy-agent": "^2.2.1",
+        "node-fetch": "^2.2.0",
+        "uuid": "^3.3.2"
       }
     },
     "temp-dir": {
@@ -6327,6 +5973,12 @@
       "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE=",
       "dev": true
     },
+    "urlgrey": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.4.tgz",
+      "integrity": "sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8=",
+      "dev": true
+    },
     "use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
@@ -6621,17 +6273,6 @@
           "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
           "dev": true
         }
-      }
-    },
-    "yargs-unparser": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.5.0.tgz",
-      "integrity": "sha512-HK25qidFTCVuj/D1VfNiEndpLIeJN78aqgR23nL3y4N0U/91cOAzqfHlF8n2BvoNDcZmJKin3ddNSvOxSr8flw==",
-      "dev": true,
-      "requires": {
-        "flat": "^4.1.0",
-        "lodash": "^4.17.11",
-        "yargs": "^12.0.5"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -19,10 +19,12 @@
     "rebuild": "npm run clean && npm run prepare && npm run build",
     "test": "lerna run test",
     "lint": "lerna run lint",
-    "lint-fix": "lerna run lint-fix"
+    "lint-fix": "lerna run lint-fix",
+    "codecov-upload": "codecov"
   },
   "devDependencies": {
-    "@types/node": "^10",
+    "@types/node": "^10.14.8",
+    "codecov": "^3.5.0",
     "lerna": "^3.14.1",
     "typescript": "^3.5.1"
   }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "version-bump": "lerna version",
     "pub": "lerna publish from-package",
     "prepare": "lerna bootstrap",
-    "clean": "lerna clean --yes",
+    "clean": "lerna run clean && lerna clean --yes",
     "build": "lerna run build",
     "rebuild": "npm run clean && npm run prepare && npm run build",
     "test": "lerna run test",

--- a/packages/clarity-cli/package-lock.json
+++ b/packages/clarity-cli/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockstack/clarity-cli",
-	"version": "0.1.1-alpha.0",
+	"version": "0.1.2-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/clarity-cli/package.json
+++ b/packages/clarity-cli/package.json
@@ -1,12 +1,50 @@
 {
   "name": "@blockstack/clarity-cli",
-  "description": "The Clarity CLI is used to manage Clarity smart contracts from the command line.",
   "version": "0.1.2-alpha.0",
+  "description": "The Clarity CLI is used to manage Clarity smart contracts from the command line.",
   "author": "Blockstack <engineering@blockstack.com> (https://blockstack.com/)",
+  "license": "MIT",
+  "repository": "blockstack/clarity-js-sdk",
+  "homepage": "https://github.com/blockstack/clarity-js-sdk/tree/master/packages/clarity-cli#readme",
+  "bugs": "https://github.com/blockstack/clarity-js-sdk/issues",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "bin": {
     "clarity": "./bin/run"
   },
-  "bugs": "https://github.com/blockstack/clarity-js-sdk/issues",
+  "engines": {
+    "node": ">=10"
+  },
+  "files": [
+    "/bin",
+    "/lib",
+    "/npm-shrinkwrap.json",
+    "/oclif.manifest.json"
+  ],
+  "oclif": {
+    "commands": "./lib/commands",
+    "bin": "clarity",
+    "plugins": [
+      "@oclif/plugin-help"
+    ],
+    "repositoryPrefix": "https://github.com/blockstack/clarity-js-sdk/blob/master/packages/clarity-cli/<%- commandPath %>"
+  },
+  "scripts": {
+    "build": "npm run clean && npm run compile",
+    "clean": "shx rm -rf ./lib tsconfig.build.tsbuildinfo",
+    "compile": "tsc --build tsconfig.build.json",
+    "prepublishOnly": "npm run build && npm run build-oclif",
+    "lint": "tslint -p tsconfig.json 'src/**/*.ts' 'test/**/*.ts'",
+    "lint-fix": "tslint --fix -p tsconfig.json 'src/**/*.ts' 'test/**/*.ts'",
+    "dev": "bin/run",
+    "postpack": "rm -f oclif.manifest.json",
+    "posttest": "tslint -p test -t stylish",
+    "build-oclif": "oclif-dev manifest && oclif-dev readme",
+    "test": "npm run build && nyc mocha"
+  },
   "dependencies": {
     "@blockstack/clarity": "^0.1.2-alpha.0",
     "@blockstack/clarity-native-bin": "^0.1.2-alpha.0",
@@ -33,44 +71,6 @@
     "tslint": "^5.17.0",
     "typescript": "^3.5.1"
   },
-  "engines": {
-    "node": ">=8.0.0"
-  },
-  "files": [
-    "/bin",
-    "/lib",
-    "/npm-shrinkwrap.json",
-    "/oclif.manifest.json"
-  ],
-  "homepage": "https://github.com/blockstack/clarity-js-sdk/tree/master/packages/clarity-cli",
-  "license": "MIT",
-  "main": "lib/index.js",
-  "oclif": {
-    "commands": "./lib/commands",
-    "bin": "clarity",
-    "plugins": [
-      "@oclif/plugin-help"
-    ],
-    "repositoryPrefix": "https://github.com/blockstack/clarity-js-sdk/blob/master/packages/clarity-cli/<%- commandPath %>"
-  },
-  "repository": "blockstack/clarity-js-sdk",
-  "publishConfig": {
-    "access": "public"
-  },
-  "scripts": {
-    "build": "npm run clean && npm run compile",
-    "clean": "shx rm -rf ./lib tsconfig.build.tsbuildinfo",
-    "compile": "tsc --build tsconfig.build.json",
-    "prepublishOnly": "npm run build && npm run build-oclif",
-    "lint": "tslint -p tsconfig.json 'src/**/*.ts' 'test/**/*.ts'",
-    "lint-fix": "tslint --fix -p tsconfig.json 'src/**/*.ts' 'test/**/*.ts'",
-    "dev": "bin/run",
-    "postpack": "rm -f oclif.manifest.json",
-    "posttest": "tslint -p test -t stylish",
-    "build-oclif": "oclif-dev manifest && oclif-dev readme",
-    "test": "npm run build && nyc mocha"
-  },
-  "types": "lib/index.d.ts",
   "nyc": {
     "all": true,
     "cache": false,

--- a/packages/clarity-cli/package.json
+++ b/packages/clarity-cli/package.json
@@ -23,7 +23,7 @@
     "@types/chai": "^4.1.7",
     "@types/fs-extra": "^7.0.0",
     "@types/mocha": "^5.2.7",
-    "@types/node": "^10",
+    "@types/node": "^10.14.8",
     "chai": "^4.2.0",
     "globby": "^9.2.0",
     "mocha": "^6.1.4",
@@ -70,5 +70,19 @@
     "build-oclif": "oclif-dev manifest && oclif-dev readme",
     "test": "npm run build && nyc mocha"
   },
-  "types": "lib/index.d.ts"
+  "types": "lib/index.d.ts",
+  "nyc": {
+    "all": true,
+    "cache": false,
+    "extension": [
+      ".ts"
+    ],
+    "include": [
+      "src"
+    ],
+    "reporter": [
+      "text",
+      "lcov"
+    ]
+  }
 }

--- a/packages/clarity-cli/test/tsconfig.json
+++ b/packages/clarity-cli/test/tsconfig.json
@@ -3,5 +3,7 @@
   "compilerOptions": {
     "noEmit": true
   },
-  "references": [{ "path": ".." }]
+  "include": [
+    "**/*"
+  ]
 }

--- a/packages/clarity-native-bin/package-lock.json
+++ b/packages/clarity-native-bin/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockstack/clarity-native-bin",
-	"version": "0.1.1-alpha.0",
+	"version": "0.1.2-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/clarity-native-bin/package-lock.json
+++ b/packages/clarity-native-bin/package-lock.json
@@ -128,15 +128,6 @@
 			"integrity": "sha512-2Y8uPt0/jwjhQ6EiluT0XCri1Dbplr0ZxfFXUz+ye13gaqE8u5gL5ppao1JrUYr9cIip5S6MvQzBS7Kke7U9VA==",
 			"dev": true
 		},
-		"@types/fs-extra": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-7.0.0.tgz",
-			"integrity": "sha512-ndoMMbGyuToTy4qB6Lex/inR98nPiNHacsgMPvy+zqMLgSxbt8VtWpDArpGp69h1fEDQHn1KB+9DWD++wgbwYA==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*"
-			}
-		},
 		"@types/mocha": {
 			"version": "5.2.7",
 			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
@@ -601,16 +592,6 @@
 				}
 			}
 		},
-		"fs-extra": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.0.1.tgz",
-			"integrity": "sha512-W+XLrggcDzlle47X/XnS7FXrXu9sDo+Ze9zpndeBxdgv88FHLm1HtmkhEwavruS6koanBjp098rUpHs65EmG7A==",
-			"requires": {
-				"graceful-fs": "^4.1.2",
-				"jsonfile": "^4.0.0",
-				"universalify": "^0.1.0"
-			}
-		},
 		"fs-minipass": {
 			"version": "1.2.6",
 			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
@@ -675,7 +656,8 @@
 		"graceful-fs": {
 			"version": "4.1.15",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-			"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
+			"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+			"dev": true
 		},
 		"growl": {
 			"version": "1.10.5",
@@ -965,14 +947,6 @@
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
 			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
 			"dev": true
-		},
-		"jsonfile": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-			"requires": {
-				"graceful-fs": "^4.1.6"
-			}
 		},
 		"lcid": {
 			"version": "2.0.0",
@@ -1877,11 +1851,6 @@
 					"optional": true
 				}
 			}
-		},
-		"universalify": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
 		},
 		"uuid": {
 			"version": "3.3.2",

--- a/packages/clarity-native-bin/package.json
+++ b/packages/clarity-native-bin/package.json
@@ -24,7 +24,6 @@
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",
-    "@types/fs-extra": "^7.0.0",
     "@types/mocha": "^5.2.7",
     "@types/node": "^10.14.8",
     "@types/node-fetch": "^2.3.4",
@@ -39,7 +38,6 @@
     "typescript": "^3.5.1"
   },
   "dependencies": {
-    "fs-extra": "^8.0.1",
     "node-fetch": "^2.6.0",
     "tar": "^4.4.8"
   },

--- a/packages/clarity-native-bin/package.json
+++ b/packages/clarity-native-bin/package.json
@@ -22,6 +22,9 @@
   "engines": {
     "node": ">=10"
   },
+  "files": [
+    "/lib"
+  ],
   "devDependencies": {
     "@types/chai": "^4.1.7",
     "@types/mocha": "^5.2.7",

--- a/packages/clarity-native-bin/package.json
+++ b/packages/clarity-native-bin/package.json
@@ -3,9 +3,22 @@
   "version": "0.1.2-alpha.0",
   "description": "Library for providing the native Clarity CLI binary",
   "author": "Blockstack <engineering@blockstack.com> (https://blockstack.com/)",
-  "repository": "blockstack/clarity-js-sdk",
   "license": "MIT",
+  "repository": "blockstack/clarity-js-sdk",
+  "homepage": "https://github.com/blockstack/clarity-js-sdk/tree/master/packages/clarity-native-bin#readme",
+  "bugs": "https://github.com/blockstack/clarity-js-sdk/issues",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "engines": {
+    "node": ">=10"
+  },
+  "files": [
+    "/lib",
+    "postInstallScript.js"
+  ],
   "scripts": {
     "build": "npm run clean && npm run compile",
     "clean": "shx rm -rf ./lib tsconfig.build.tsbuildinfo",
@@ -16,15 +29,10 @@
     "test": "npm run build && nyc mocha",
     "postinstall": "node postInstallScript.js"
   },
-  "publishConfig": {
-    "access": "public"
+  "dependencies": {
+    "node-fetch": "^2.6.0",
+    "tar": "^4.4.8"
   },
-  "engines": {
-    "node": ">=10"
-  },
-  "files": [
-    "/lib"
-  ],
   "devDependencies": {
     "@types/chai": "^4.1.7",
     "@types/mocha": "^5.2.7",
@@ -39,10 +47,6 @@
     "ts-node": "^8.2.0",
     "tslint": "^5.17.0",
     "typescript": "^3.5.1"
-  },
-  "dependencies": {
-    "node-fetch": "^2.6.0",
-    "tar": "^4.4.8"
   },
   "nyc": {
     "all": true,

--- a/packages/clarity-native-bin/package.json
+++ b/packages/clarity-native-bin/package.json
@@ -26,7 +26,7 @@
     "@types/chai": "^4.1.7",
     "@types/fs-extra": "^7.0.0",
     "@types/mocha": "^5.2.7",
-    "@types/node": "^10",
+    "@types/node": "^10.14.8",
     "@types/node-fetch": "^2.3.4",
     "@types/tar": "^4.0.0",
     "chai": "^4.2.0",

--- a/packages/clarity-native-bin/postInstallScript.js
+++ b/packages/clarity-native-bin/postInstallScript.js
@@ -1,17 +1,47 @@
-try {
-  require("./lib/directInstall");
-} catch (e) {
-  if (e.code === 'MODULE_NOT_FOUND') {
-    console.warn("Typescript lib has not been compiled. Attempting install with \"npx ts-node\".");
-    tsNodeInstall();
-  } else {
+const fs = require("fs");
+const path = require("path");
+
+// Detect if running in dev environment.
+const tsConfigBuildFile = path.join(__dirname, "tsconfig.build.json");
+if (fs.existsSync(tsConfigBuildFile)) {
+  tsNodeInstall();
+} else {
+  try {
+    require("./lib/directInstall");
+  } catch (e) {
+    if (e.code === 'MODULE_NOT_FOUND') {
+      console.error("Script \"./lib/directInstall.js\" not found, and dev environment to run \"./src/directInstall.ts\" not detected.");
+    }
     throw e;
   }
 }
 
 function tsNodeInstall() {
+
+  function getTsNodePkg() {
+    const tsNodePkgName = "ts-node";
+    // Try using the ts-node package version typically specified in env vars by npm.
+    const tsNodeDevDep = "npm_package_devDependencies_ts_node";
+    if (process.env && process.env[tsNodeDevDep]) {
+      return `${tsNodePkgName}@${process.env[tsNodeDevDep]}`;
+    } else {
+      // Otherwise, try loading the version from the package.json file.
+      try {
+        const tsNodePkgJsonVersion = require("./package.json")["devDependencies"]["ts-node"];
+        return `${tsNodePkgName}@${tsNodePkgJsonVersion}`;
+      } catch (err) {
+        // ignore
+      }
+    }
+    console.warn("Could not detect ts-node version to use, no version will be specified.");
+    return tsNodePkgName;
+  }
+
   const childProcess = require("child_process");
-  const path = require("path");
-  const result = childProcess.execFileSync("npx", ["ts-node", path.join(__dirname, "src", "directInstall.ts")]);
+  const tsNodePkg = getTsNodePkg();
+  const directInstallTsFile = path.join(__dirname, "src", "directInstall.ts");
+  const tsNodeExecArgs = [tsNodePkg, "--project", tsConfigBuildFile, directInstallTsFile];
+  console.log(`Running: npx ${tsNodeExecArgs.join(" ")}`);
+  const result = childProcess.execFileSync("npx", tsNodeExecArgs);
   console.log(result.toString());
 }

--- a/packages/clarity-native-bin/postInstallScript.js
+++ b/packages/clarity-native-bin/postInstallScript.js
@@ -1,19 +1,17 @@
 try {
-  const lib = require("./lib/index");
-  lib.installDefaultPath().catch(error => {
-      console.error(`Failed to install clarity-cli native binary: ${error}`);
-      process.exit(1);
-  }).then(installSuccessful => {
-    if (!installSuccessful) {
-      process.exit(1);
-    } else {
-      process.exit();
-    }
-  });
+  require("./lib/directInstall");
 } catch (e) {
   if (e.code === 'MODULE_NOT_FOUND') {
-    console.log("Typescript lib has not been compiled. Skipping post-installation of the native clarity-cli binary.")
+    console.warn("Typescript lib has not been compiled. Attempting install with \"npx ts-node\".");
+    tsNodeInstall();
   } else {
     throw e;
   }
+}
+
+function tsNodeInstall() {
+  const childProcess = require("child_process");
+  const path = require("path");
+  const result = childProcess.execFileSync("npx", ["ts-node", path.join(__dirname, "src", "directInstall.ts")]);
+  console.log(result.toString());
 }

--- a/packages/clarity-native-bin/src/cargoBuild.ts
+++ b/packages/clarity-native-bin/src/cargoBuild.ts
@@ -1,4 +1,4 @@
-import * as fs from "fs-extra";
+import * as fs from "fs";
 import * as path from "path";
 import { executeCommand } from "./execUtil";
 import { getExecutableFileName, makeUniqueTempDir } from "./fsUtil";

--- a/packages/clarity-native-bin/src/directInstall.ts
+++ b/packages/clarity-native-bin/src/directInstall.ts
@@ -1,0 +1,19 @@
+import { installDefaultPath } from ".";
+
+// Warning: Importing this module will trigger an immediate installation attempt that will
+// exit the process if failed. This script is only intended to be invoked from the
+// postInstall script.
+
+export default (async () => {
+  try {
+    const installSuccessful = await installDefaultPath();
+    if (!installSuccessful) {
+      process.exit(1);
+    } else {
+      process.exit();
+    }
+  } catch (error) {
+    console.error(`Failed to install clarity-cli native binary: ${error}`);
+    process.exit(1);
+  }
+})();

--- a/packages/clarity-native-bin/src/fetchDist.ts
+++ b/packages/clarity-native-bin/src/fetchDist.ts
@@ -1,4 +1,4 @@
-import * as fs from "fs-extra";
+import * as fs from "fs";
 import fetch from "node-fetch";
 import * as os from "os";
 import * as path from "path";

--- a/packages/clarity-native-bin/src/fsUtil.ts
+++ b/packages/clarity-native-bin/src/fsUtil.ts
@@ -1,4 +1,4 @@
-import * as fs from "fs-extra";
+import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import { ILogger } from "./logger";
@@ -52,7 +52,7 @@ export async function verifyOutputFile(
       logger.log(`Overwriting existing file: ${fullFilePath}`);
       fs.unlinkSync(fullFilePath);
     } else {
-      fs.ensureDirSync(outputDirectory);
+      fs.mkdirSync(outputDirectory, { recursive: true });
     }
     return true;
   } catch (error) {

--- a/packages/clarity-native-bin/src/fsUtil.ts
+++ b/packages/clarity-native-bin/src/fsUtil.ts
@@ -29,11 +29,11 @@ export function getExecutableFileName(file: string) {
  * Ensures the provided output directory exists and is writable.
  * Deletes the provided output file if it already exists and overwrite has been specified.
  */
-export async function verifyOutputFile(
+export function verifyOutputFile(
   logger: ILogger,
   overwriteExisting: boolean,
   outputFilePath: string
-): Promise<boolean> {
+): boolean {
   const fullFilePath = path.resolve(outputFilePath);
   const outputDirectory = path.dirname(fullFilePath);
 

--- a/packages/clarity-native-bin/src/index.ts
+++ b/packages/clarity-native-bin/src/index.ts
@@ -80,11 +80,7 @@ export async function install(opts: {
   outputFilePath: string;
   versionTag: string;
 }): Promise<boolean> {
-  const outputIsValid = await verifyOutputFile(
-    opts.logger,
-    opts.overwriteExisting,
-    opts.outputFilePath
-  );
+  const outputIsValid = verifyOutputFile(opts.logger, opts.overwriteExisting, opts.outputFilePath);
   if (!outputIsValid) {
     return false;
   }

--- a/packages/clarity-native-bin/test/cargoBin.ts
+++ b/packages/clarity-native-bin/test/cargoBin.ts
@@ -11,7 +11,7 @@ describe("install via build from source", () => {
     }
   });
 
-  it("get binary throws if not exists", async () => {
+  it("get binary throws if not exists after source install", async () => {
     assert.throws(() => {
       index.getDefaultBinaryFilePath({ checkExists: true });
     });
@@ -21,7 +21,7 @@ describe("install via build from source", () => {
     await index.installDefaultPath({ fromSource: true });
   });
 
-  it("native binary exists after default install", async () => {
+  it("native binary exists after install to default path from source", async () => {
     index.getDefaultBinaryFilePath({ checkExists: true });
   });
 });

--- a/packages/clarity-native-bin/test/cargoBin.ts
+++ b/packages/clarity-native-bin/test/cargoBin.ts
@@ -18,7 +18,8 @@ describe("install via build from source", () => {
   });
 
   it("default install from source", async () => {
-    await index.installDefaultPath({ fromSource: true });
+    const success = await index.installDefaultPath({ fromSource: true });
+    assert.isTrue(success);
   });
 
   it("native binary exists after install to default path from source", async () => {

--- a/packages/clarity-native-bin/test/fetchDist.ts
+++ b/packages/clarity-native-bin/test/fetchDist.ts
@@ -11,17 +11,17 @@ describe("install via dist", () => {
     }
   });
 
-  it("get binary throws if not exists", async () => {
+  it("get binary throws if not exists after dist install", async () => {
     assert.throws(() => {
       index.getDefaultBinaryFilePath({ checkExists: true });
     });
   });
 
-  it("default install", async () => {
+  it("default install from dist", async () => {
     await index.installDefaultPath({ fromSource: false });
   });
 
-  it("native binary exists after default install", async () => {
+  it("native binary exists after install to default path from dist download", async () => {
     index.getDefaultBinaryFilePath({ checkExists: true });
   });
 });

--- a/packages/clarity-native-bin/test/fetchDist.ts
+++ b/packages/clarity-native-bin/test/fetchDist.ts
@@ -18,7 +18,8 @@ describe("install via dist", () => {
   });
 
   it("default install from dist", async () => {
-    await index.installDefaultPath({ fromSource: false });
+    const success = await index.installDefaultPath({ fromSource: false });
+    assert.isTrue(success);
   });
 
   it("native binary exists after install to default path from dist download", async () => {

--- a/packages/clarity-tslint/package-lock.json
+++ b/packages/clarity-tslint/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockstack/clarity-tslint",
-	"version": "0.1.1-alpha.0",
+	"version": "0.1.2-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/clarity-tutorials/package-lock.json
+++ b/packages/clarity-tutorials/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockstack/clarity-tutorials",
-	"version": "0.1.1-alpha.0",
+	"version": "0.1.2-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/clarity-tutorials/package.json
+++ b/packages/clarity-tutorials/package.json
@@ -16,8 +16,7 @@
     "prepublishOnly": "npm run build",
     "lint": "tslint -p tsconfig.json 'src/**/*.ts' 'test/**/*.ts'",
     "lint-fix": "tslint --fix -p tsconfig.json 'src/**/*.ts' 'test/**/*.ts'",
-    "test": "npm run build && nyc mocha",
-    "tdd": "nodemon -e ts -w ./src -w ./test -x npm run test"
+    "test": "npm run build && nyc mocha"
   },
   "engines": {
     "node": ">=10"
@@ -36,5 +35,19 @@
     "ts-node": "^8.2.0",
     "tslint": "^5.17.0",
     "typescript": "^3.5.1"
+  },
+  "nyc": {
+    "all": true,
+    "cache": false,
+    "extension": [
+      ".ts"
+    ],
+    "include": [
+      "src"
+    ],
+    "reporter": [
+      "text",
+      "lcov"
+    ]
   }
 }

--- a/packages/clarity-tutorials/package.json
+++ b/packages/clarity-tutorials/package.json
@@ -21,6 +21,12 @@
   "engines": {
     "node": ">=10"
   },
+  "files": [
+    "/src",
+    "/test",
+    "/lib",
+    "/contracts"
+  ],
   "dependencies": {
     "@blockstack/clarity": "^0.1.1-alpha.0",
     "@blockstack/clarity-native-bin": "^0.1.1-alpha.0"

--- a/packages/clarity-tutorials/test/mocha.opts
+++ b/packages/clarity-tutorials/test/mocha.opts
@@ -1,6 +1,5 @@
 --require ts-node/register/transpile-only
 --require source-map-support/register
---watch-extensions ts
+--extension ts
+--timeout 0
 --recursive
---reporter spec
---timeout 10000

--- a/packages/clarity/README.md
+++ b/packages/clarity/README.md
@@ -1,0 +1,9 @@
+# @blockstack/clarity
+
+Core lib package.
+
+
+### Usage
+
+TODO
+

--- a/packages/clarity/package-lock.json
+++ b/packages/clarity/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockstack/clarity",
-	"version": "0.1.1-alpha.0",
+	"version": "0.1.2-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/clarity/package.json
+++ b/packages/clarity/package.json
@@ -39,5 +39,19 @@
     "ts-node": "^8.2.0",
     "tslint": "^5.17.0",
     "typescript": "^3.5.1"
+  },
+  "nyc": {
+    "all": true,
+    "cache": false,
+    "extension": [
+      ".ts"
+    ],
+    "include": [
+      "src"
+    ],
+    "reporter": [
+      "text",
+      "lcov"
+    ]
   }
 }

--- a/packages/clarity/package.json
+++ b/packages/clarity/package.json
@@ -22,6 +22,9 @@
   "engines": {
     "node": ">=10"
   },
+  "files": [
+    "/lib"
+  ],
   "dependencies": {
 
   },

--- a/packages/clarity/package.json
+++ b/packages/clarity/package.json
@@ -4,7 +4,20 @@
   "description": "Clarity JS SDK - Core library",
   "author": "Blockstack <engineering@blockstack.com> (https://blockstack.com/)",
   "license": "MIT",
+  "repository": "blockstack/clarity-js-sdk",
+  "homepage": "https://github.com/blockstack/clarity-js-sdk/tree/master/packages/clarity#readme",
+  "bugs": "https://github.com/blockstack/clarity-js-sdk/issues",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "engines": {
+    "node": ">=10"
+  },
+  "files": [
+    "/lib"
+  ],
   "scripts": {
     "build": "npm run clean && npm run compile",
     "clean": "shx rm -rf ./lib tsconfig.build.tsbuildinfo",
@@ -12,19 +25,8 @@
     "prepublishOnly": "npm run build",
     "lint": "tslint -p tsconfig.json 'src/**/*.ts' 'test/**/*.ts'",
     "lint-fix": "tslint --fix -p tsconfig.json 'src/**/*.ts' 'test/**/*.ts'",
-    "test": "npm run build && nyc mocha",
-    "tdd": "nodemon -e ts -w ./src -x npm run test"
+    "test": "npm run build && nyc mocha"
   },
-  "repository": "blockstack/clarity-js-sdk",
-  "publishConfig": {
-    "access": "public"
-  },
-  "engines": {
-    "node": ">=10"
-  },
-  "files": [
-    "/lib"
-  ],
   "peerDependencies": {
     "@blockstack/clarity-native-bin": "^0.1.2-alpha.0"
   },

--- a/packages/clarity/test/main.ts
+++ b/packages/clarity/test/main.ts
@@ -1,9 +1,30 @@
 import { assert, expect, should } from "chai";
 import "mocha";
+import * as path from "path";
 import * as index from "../src";
+import { fileExists, getTempFilePath } from "../src/utils/fsUtil";
+import { executeCommand } from "../src/utils/processUtil";
 
-describe("core tests", () => {
-  it("TODO", () => {
-    assert.ok(true, "todo");
+describe("process exec", () => {
+  it("reads stdout", async () => {
+    const result = await executeCommand("echo", ["hello world"]);
+    assert.equal(result.stdout.trim(), "hello world");
+  });
+});
+
+describe("fs util", () => {
+  it("get temp file path", async () => {
+    const tempFilePath = getTempFilePath("example_{uniqueID}_file");
+    assert.ok(tempFilePath);
+    const fileName = path.basename(tempFilePath);
+    assert.isTrue(fileName.startsWith("example_"));
+    assert.isTrue(fileName.endsWith("_file"));
+    assert.isTrue(path.isAbsolute(tempFilePath));
+  });
+
+  it("random temp file does not exist", () => {
+    const tempFilePath = getTempFilePath();
+    const isFileExists = fileExists(tempFilePath);
+    assert.isFalse(isFileExists);
   });
 });


### PR DESCRIPTION
Resolves https://github.com/blockstack/clarity-js-sdk/issues/8

* Configure test code coverage reporting with codecov.io integration in all applicable packages. 
* Implement CircleCI -- performs builds, runs tests, and uploads code coverage reports to circleCI. 
* More robust `clarity-native-bin` package npm postInstall script -- in dev environments, where the compiled `lib` dir is not available, it will use `npx ts-node` to run the native bin installation script.