### PR TITLE
blockstack-core git branch/tag configurable via env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ Repo structure and project build instructions for contributors.
   -- distributes are automatically installed on MacOS, Windows (64-bit), and Linux (64-bit). 
   > _It will be compiled from source if using an OS or architecture not listed. 
   > This requires the Rust toolchain -- [rustup](https://rustup.rs/) is the recommended installer. 
-  > A C compiler must also be available (gcc, clang, and msvc are supported)._
+  > A C compiler must also be available (gcc, clang, and msvc are supported). 
+  > See [clarity-native-bin](packages/clarity-native-bin/README.md) for more details._
 
 ### Build Instructions
 

--- a/packages/clarity-native-bin/README.md
+++ b/packages/clarity-native-bin/README.md
@@ -1,0 +1,32 @@
+# @blockstack/clarity-native-bin
+
+This package installs the system-specific native [`clarity-cli`](https://github.com/blockstack/blockstack-core/blob/develop/src/clarity_cli.rs) binary. 
+
+The JS module also provides programmatic access to the binary file path and the installation functions. 
+
+## Installation
+
+An installation script runs automatically when this package is installed via `npm install` (or an equivalent package install tool/command). Pre-built dist files are downloaded if the platform & arch is supported, otherwise, it attempts to compile the binary from source. 
+
+
+#### Controlling Installation Options
+
+Force install via source compilation by specifying either the `BLOCKSTACK_CORE_SOURCE_TAG` or `BLOCKSTACK_CORE_SOURCE_BRANCH` 
+environment variables. The variable must be available during the npm install script. If found then the script will not attempt to download 
+a pre-compiled distributable. The value must be set to a git tag or branch on the `https://github.com/blockstack/blockstack-core.git` 
+repo. 
+
+For example, to specify a feature branch for use during local development in this SDK monorepo:
+```
+BLOCKSTACK_CORE_SOURCE_BRANCH="feature/new-thingy" npm run rebuild
+```
+
+
+## Source Compilation Requirements
+
+If compiling from source then the Rust toolchain and a C compiler must be available. 
+
+* Specifically, `cargo` must be available in PATH. [rustup](https://rustup.rs/) is the recommended toolchain installer. 
+* See C compiler requirement details at [cc-rs](https://github.com/alexcrichton/cc-rs) (gcc, clang, and msvc are supported). 
+
+

--- a/packages/clarity-native-bin/postInstallScript.js
+++ b/packages/clarity-native-bin/postInstallScript.js
@@ -42,6 +42,5 @@ function tsNodeInstall() {
   const directInstallTsFile = path.join(__dirname, "src", "directInstall.ts");
   const tsNodeExecArgs = [tsNodePkg, "--project", tsConfigBuildFile, directInstallTsFile];
   console.log(`Running: npx ${tsNodeExecArgs.join(" ")}`);
-  const result = childProcess.execFileSync("npx", tsNodeExecArgs);
-  console.log(result.toString());
+  childProcess.execFileSync("npx", tsNodeExecArgs, { stdio: ['pipe', process.stdout, process.stderr] });
 }


### PR DESCRIPTION
Ability to specify the blockstack-core repo git branch or tag via env vars -- easier testing of SDK against Clarity PRs. 

Usage and details included in the README.

Example:
```
BLOCKSTACK_CORE_SOURCE_BRANCH="feature/new-thingy" npm run rebuild
cd packages/clarity-tutorials
npm test
```