### PR TITLE
Update tutorial contracts to use tuple shorthand syntax 

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "clean": "lerna run clean && lerna clean --yes",
     "build": "lerna run build",
     "rebuild": "npm run clean && npm run prepare && npm run build",
-    "test": "lerna run test",
+    "test": "lerna run test --stream",
     "lint": "lerna run lint",
     "lint-fix": "lerna run lint-fix",
     "codecov-upload": "codecov"

--- a/packages/clarity-native-bin/src/index.ts
+++ b/packages/clarity-native-bin/src/index.ts
@@ -9,7 +9,7 @@ import { ILogger } from "./logger";
  * Should correspond to both a git tag on the blockstack-core repo and a
  * set of clarity-binary distributables uploaded to the cloud storage endpoint.
  */
-export const CORE_SDK_TAG = "clarity-sdk-v0.0.3";
+export const CORE_SDK_TAG = "clarity-sdk-v0.0.4";
 
 export const BLOCKSTACK_CORE_SOURCE_TAG_ENV_VAR = "BLOCKSTACK_CORE_SOURCE_TAG";
 export const BLOCKSTACK_CORE_SOURCE_BRANCH_ENV_VAR = "BLOCKSTACK_CORE_SOURCE_BRANCH";

--- a/packages/clarity-tutorials/contracts/rocket-tutorial/rocket-market.scm
+++ b/packages/clarity-tutorials/contracts/rocket-tutorial/rocket-market.scm
@@ -19,7 +19,7 @@
 
 ;;; Storage
 (define-map rockets-info
-  ((rocket-id int)) 
+  ((rocket-id int))
   ((owner principal)))
 (define-map rockets-count
   ((owner principal))
@@ -43,15 +43,15 @@
 ;; returns: int
 (define (balance-of (account principal))
   (default-to 0
-    (get count 
-         (fetch-entry rockets-count (tuple (owner account))))))
+    (get count
+         (fetch-entry rockets-count ((owner account))))))
 
 ;; Check if the transaction has been sent by the factory-address
 ;; returns: boolean
 (define (is-tx-from-factory)
   (let ((address
-         (get address 
-              (expects! (fetch-entry factory-address (tuple (id 0)))
+         (get address
+              (expects! (fetch-entry factory-address ((id 0)))
                         'false))))
     (eq? tx-sender address)))
 
@@ -59,9 +59,9 @@
 ;; args:
 ;; @rocket-id (int) the id of the rocket to identify
 ;; returns: option<principal>
-(define (owner-of (rocket-id int)) 
-  (get owner 
-    (fetch-entry rockets-info (tuple (rocket-id rocket-id)))))
+(define (owner-of (rocket-id int))
+  (get owner
+    (fetch-entry rockets-info ((rocket-id rocket-id)))))
 
 ;;; Public functions
 
@@ -74,21 +74,21 @@
 (define-public (transfer (recipient principal) (rocket-id int))
   (let ((balance-sender (balance-of tx-sender))
         (balance-recipient (balance-of recipient)))
-    (if (and 
+    (if (and
          (eq? (expects! (owner-of rocket-id) no-such-rocket-err)
               tx-sender)
          (> balance-sender 0)
          (not (eq? recipient tx-sender)))
         (begin
-          (set-entry! rockets-info 
-                      (tuple (rocket-id rocket-id))
-                      (tuple (owner recipient)))
-          (set-entry! rockets-count 
-                      (tuple (owner recipient))
-                      (tuple (count (+ balance-recipient 1))))
-          (set-entry! rockets-count 
-                      (tuple (owner tx-sender))
-                      (tuple (count (- balance-sender 1))))
+          (set-entry! rockets-info
+                      ((rocket-id rocket-id))
+                      ((owner recipient)))
+          (set-entry! rockets-count
+                      ((owner recipient))
+                      ((count (+ balance-recipient 1))))
+          (set-entry! rockets-count
+                      ((owner tx-sender))
+                      ((count (- balance-sender 1))))
           (ok rocket-id))
         bad-rocket-transfer-err)))
 
@@ -103,12 +103,12 @@
   (if (is-tx-from-factory)
       (let ((current-balance (balance-of owner)))
         (begin
-          (insert-entry! rockets-info 
-                         (tuple (rocket-id rocket-id))
-                         (tuple (owner owner))) 
-          (set-entry! rockets-count 
-                      (tuple (owner owner))
-                      (tuple (count (+ 1 current-balance)))) 
+          (insert-entry! rockets-info
+                         ((rocket-id rocket-id))
+                         ((owner owner)))
+          (set-entry! rockets-count
+                      ((owner owner))
+                      ((count (+ 1 current-balance))))
           (ok rocket-id)))
       unauthorized-mint-err))
 
@@ -118,10 +118,10 @@
 ;; returns: Response<Principal, int>
 (define-public (set-factory)
   (let ((factory-entry
-         (fetch-entry factory-address (tuple (id 0)))))
-    (if (and (is-none? factory-entry) 
-             (insert-entry! factory-address 
-                            (tuple (id 0))
-                            (tuple (address tx-sender))))
+         (fetch-entry factory-address ((id 0)))))
+    (if (and (is-none? factory-entry)
+             (insert-entry! factory-address
+                            ((id 0))
+                            ((address tx-sender))))
         (ok tx-sender)
         factory-already-set-err)))

--- a/packages/clarity-tutorials/contracts/rocket-tutorial/rocket-token.scm
+++ b/packages/clarity-tutorials/contracts/rocket-tutorial/rocket-token.scm
@@ -18,8 +18,8 @@
 ;;;; Rocket-Token
 
 ;;; Storage
-(define-map balances 
-  ((owner principal)) 
+(define-map balances
+  ((owner principal))
   ((balance int)))
 (define-map total-supply
   ((id int))
@@ -31,8 +31,8 @@
 ;; returns: int
 (define (get-total-supply)
   (default-to 0
-   (get value 
-    (fetch-entry total-supply (tuple (id 0))))))
+   (get value
+    (fetch-entry total-supply ((id 0))))))
 
 ;; Gets the amount of tokens owned by the specified address
 ;; args:
@@ -40,8 +40,8 @@
 ;; returns: int
 (define (balance-of (account principal))
   (default-to 0
-    (get balance 
-         (fetch-entry balances (tuple (owner account))))))
+    (get balance
+         (fetch-entry balances ((owner account))))))
 
 ;; Credits balance of a specified principal
 ;; args:
@@ -53,10 +53,10 @@
     'false
     (let ((current-balance (balance-of account)))
       (begin
-        (set-entry! balances 
-          (tuple (owner account))
+        (set-entry! balances
+          ((owner account))
           ;; Overflows will cause exceptions
-          (tuple (balance (+ amount current-balance))))
+          ((balance (+ amount current-balance))))
         'true))))
 
 ;; Debits balance of a specified principal
@@ -70,8 +70,8 @@
       'false
       (begin
         (set-entry! balances
-          (tuple (owner account))
-          (tuple (balance (- balance amount))))
+          ((owner account))
+          ((balance (- balance amount))))
         'true))))
 
 ;; Transfers tokens to a specified principal
@@ -81,10 +81,10 @@
 ;; @amount (int) the amount of tokens to transfer
 ;; returns: boolean
 (define (transfer! (sender principal) (recipient principal) (amount int))
-  (if (and  
-        (not (eq? sender recipient)) 
-        (debit-balance! sender amount) 
-        (credit-balance! recipient amount)) 
+  (if (and
+        (not (eq? sender recipient))
+        (debit-balance! sender amount)
+        (credit-balance! recipient amount))
     'true
     'false))
 
@@ -109,19 +109,19 @@
   (if (<= amount 0)
     'false
     (let ((balance (balance-of account)))
-      (begin 
+      (begin
         (set-entry! balances
-          (tuple (owner account))
-          (tuple (balance (+ balance amount))))
-        (set-entry! total-supply 
-          (tuple (id 0))
-          (tuple (value (+ (get-total-supply) amount)))) 
+          ((owner account))
+          ((balance (+ balance amount))))
+        (set-entry! total-supply
+          ((id 0))
+          ((value (+ (get-total-supply) amount))))
         'true))))
 
 ;; Initialize the contract
 (begin
-  (set-entry! total-supply 
-    (tuple (id 0))
-    (tuple (value 0))) 
+  (set-entry! total-supply
+    ((id 0))
+    ((value 0)))
   (mint! 'SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7 20) ;; Alice
   (mint! 'S02J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKPVKG2CE 10)) ;; Bob

--- a/packages/clarity-tutorials/contracts/tokens/fungible-token.scm
+++ b/packages/clarity-tutorials/contracts/tokens/fungible-token.scm
@@ -18,11 +18,11 @@
 ;; Fungible Token, modeled after ERC-20
 
 ;; Storage
-(define-map balances 
-  ((owner principal)) 
+(define-map balances
+  ((owner principal))
   ((balance int)))
-(define-map allowances 
-  ((spender principal) (owner principal)) 
+(define-map allowances
+  ((spender principal) (owner principal))
   ((allowance int)))
 (define total-supply 0)
 
@@ -35,15 +35,15 @@
 ;; Gets the amount of tokens owned by the specified address.
 (define (balance-of (account principal))
   (default-to 0
-    (get balance 
-         (fetch-entry balances (tuple (owner account))))))
+    (get balance
+         (fetch-entry balances ((owner account))))))
 
 ;; Gets the amount of tokens that an owner allowed to a spender.
 (define (allowance-of (spender principal) (owner principal))
-  (default-to 0 
+  (default-to 0
     (get allowance
-         (fetch-entry allowances (tuple 
-                                  (owner owner) 
+         (fetch-entry allowances (
+                                  (owner owner)
                                   (spender spender))))))
 
 ;; Credits balance of a specified principal.
@@ -52,9 +52,9 @@
     'false
     (let ((current-balance (balance-of account)))
       (begin
-        (set-entry! balances 
-          (tuple (owner account))
-          (tuple (balance (+ amount current-balance)))) 
+        (set-entry! balances
+          ((owner account))
+          ((balance (+ amount current-balance))))
         'true)))) ;; Overflow management?
 
 ;; Debits balance of a specified principal.
@@ -64,16 +64,16 @@
       'false
       (begin
         (set-entry! balances
-          (tuple (owner account))
-          (tuple (balance (- balance amount))))
+          ((owner account))
+          ((balance (- balance amount))))
         'true))))
 
 ;; Transfers tokens to a specified principal.
 (define (transfer! (sender principal) (recipient principal) (amount int))
-  (if (and  
-        (not (eq? sender recipient)) 
-        (debit-balance! sender amount) 
-        (credit-balance! recipient amount)) 
+  (if (and
+        (not (eq? sender recipient))
+        (debit-balance! sender amount)
+        (credit-balance! recipient amount))
     'true
     'false))
 
@@ -84,8 +84,8 @@
       'true
       (begin
         (set-entry! allowances
-          (tuple (spender spender) (owner owner))
-          (tuple (allowance (- allowance amount))))
+          ((spender spender) (owner owner))
+          ((allowance (- allowance amount))))
         'true))))
 
 ;; Internal - Increase allowance of a specified spender.
@@ -94,10 +94,10 @@
     (if (<= amount 0)
       'false
       (begin
-        (set-entry! allowances 
-          (tuple (spender spender) (owner owner))
-          (tuple (allowance (+ allowance amount))))
-        'true)))) 
+        (set-entry! allowances
+          ((spender spender) (owner owner))
+          ((allowance (+ allowance amount))))
+        'true))))
 
 ;; Public functions
 
@@ -138,10 +138,10 @@
   (if (<= amount 0)
       (err 'false)
       (let ((balance (balance-of account)))
-        (begin 
+        (begin
           (set-entry! balances
-                      (tuple (owner account))
-                      (tuple (balance (+ balance amount))))
+                      ((owner account))
+                      ((balance (+ balance amount))))
           (ok amount)))))
 
 ;; Initialize the contract


### PR DESCRIPTION
This PR is pending merge of https://github.com/blockstack/blockstack-core/pull/1007

Currently requires the `feature/tuple-syntax` branch of blockstack-core:
```
BLOCKSTACK_CORE_SOURCE_BRANCH="feature/tuple-syntax" npm i
cd packages/clarity-tutorials
npm test
```