### PR TITLE
Add Optional and Response types to contract interface

### DIFF
--- a/packages/clarity/src/core/contractInterface.ts
+++ b/packages/clarity/src/core/contractInterface.ts
@@ -1,0 +1,75 @@
+export interface BufferAtomicType {
+  BufferType: number;
+}
+
+export interface OptionalType {
+  OptionalType: TypeSignature;
+}
+
+export const ResponseTypeOk = 0;
+export const ResponseTypeError = 1;
+
+export interface ResponseType {
+  ResponseType: {
+    [ResponseTypeOk]: TypeSignature;
+    [ResponseTypeError]: TypeSignature;
+  };
+}
+
+export interface TupleAtomicType {
+  TupleType: {
+    type_map: {
+      [name: string]: TypeSignature;
+    };
+  };
+}
+
+export type AtomicType =
+  | "NoType"
+  | "IntType"
+  | "BoolType"
+  | "PrincipalType"
+  | BufferAtomicType
+  | OptionalType
+  | ResponseType
+  | TupleAtomicType;
+
+export interface TypeSignature {
+  atomic_type: AtomicType;
+  list_dimensions?: number | null;
+}
+
+export interface FunctionArg extends TypeSignature {
+  name: string;
+}
+
+export const FunctionArgTypes = 0;
+export const FunctionReturnType = 1;
+
+export interface FunctionTypeSignatureArray {
+  [FunctionArgTypes]: FunctionArg[];
+  [FunctionReturnType]: TypeSignature;
+}
+
+export interface FunctionTypeSignature {
+  Fixed: FunctionTypeSignatureArray;
+  // Variadic?: FunctionTypeSignatureArray;
+}
+
+export interface ContractInterface {
+  private_function_types: {
+    [name: string]: FunctionTypeSignature;
+  };
+  public_function_types: {
+    [name: string]: FunctionTypeSignature;
+  };
+  read_only_function_types: {
+    [name: string]: FunctionTypeSignature;
+  };
+  variable_types: {
+    [name: string]: TypeSignature;
+  };
+  map_types: {
+    [name: string]: TypeSignature[];
+  };
+}

--- a/packages/clarity/src/core/types.ts
+++ b/packages/clarity/src/core/types.ts
@@ -1,3 +1,4 @@
+import { ContractInterface } from "./contractInterface";
 import { ResultInterface } from "./result";
 
 export interface Var {
@@ -13,5 +14,4 @@ export interface Receipt extends ResultInterface<string, string> {
   debugOutput?: string;
 }
 
-// tslint:disable-next-line: ban-types
-export interface CheckResult extends ResultInterface<Object, string> {}
+export interface CheckResult extends ResultInterface<ContractInterface, string> {}

--- a/packages/clarity/test/contract-interface-samples/names.json
+++ b/packages/clarity/test/contract-interface-samples/names.json
@@ -1,0 +1,165 @@
+{
+  "private_function_types": {
+    "price-function": {
+      "Fixed": [
+        [
+          {
+            "atomic_type": "IntType",
+            "list_dimensions": null,
+            "name": "name"
+          }
+        ],
+        {
+          "atomic_type": "IntType",
+          "list_dimensions": null
+        }
+      ]
+    }
+  },
+  "variable_types": {
+    "burn-address": {
+      "atomic_type": "PrincipalType",
+      "list_dimensions": null
+    }
+  },
+  "public_function_types": {
+    "preorder": {
+      "Fixed": [
+        [
+          {
+            "atomic_type": {
+              "BufferType": 20
+            },
+            "list_dimensions": null,
+            "name": "name-hash"
+          },
+          {
+            "atomic_type": "IntType",
+            "list_dimensions": null,
+            "name": "name-price"
+          }
+        ],
+        {
+          "atomic_type": {
+            "ResponseType": [
+              {
+                "atomic_type": "IntType",
+                "list_dimensions": null
+              },
+              {
+                "atomic_type": {
+                  "BufferType": 21
+                },
+                "list_dimensions": null
+              }
+            ]
+          },
+          "list_dimensions": null
+        }
+      ]
+    },
+    "register": {
+      "Fixed": [
+        [
+          {
+            "atomic_type": "PrincipalType",
+            "list_dimensions": null,
+            "name": "recipient-principal"
+          },
+          {
+            "atomic_type": "IntType",
+            "list_dimensions": null,
+            "name": "name"
+          },
+          {
+            "atomic_type": "IntType",
+            "list_dimensions": null,
+            "name": "salt"
+          }
+        ],
+        {
+          "atomic_type": {
+            "ResponseType": [
+              {
+                "atomic_type": "IntType",
+                "list_dimensions": null
+              },
+              {
+                "atomic_type": {
+                  "BufferType": 31
+                },
+                "list_dimensions": null
+              }
+            ]
+          },
+          "list_dimensions": null
+        }
+      ]
+    }
+  },
+  "read_only_function_types": {},
+  "map_types": {
+    "name-map": [
+      {
+        "atomic_type": {
+          "TupleType": {
+            "type_map": {
+              "name": {
+                "atomic_type": "IntType",
+                "list_dimensions": null
+              }
+            }
+          }
+        },
+        "list_dimensions": null
+      },
+      {
+        "atomic_type": {
+          "TupleType": {
+            "type_map": {
+              "owner": {
+                "atomic_type": "PrincipalType",
+                "list_dimensions": null
+              }
+            }
+          }
+        },
+        "list_dimensions": null
+      }
+    ],
+    "preorder-map": [
+      {
+        "atomic_type": {
+          "TupleType": {
+            "type_map": {
+              "name-hash": {
+                "atomic_type": {
+                  "BufferType": 20
+                },
+                "list_dimensions": null
+              }
+            }
+          }
+        },
+        "list_dimensions": null
+      },
+      {
+        "atomic_type": {
+          "TupleType": {
+            "type_map": {
+              "buyer": {
+                "atomic_type": "PrincipalType",
+                "list_dimensions": null
+              },
+              "paid": {
+                "atomic_type": "IntType",
+                "list_dimensions": null
+              }
+            }
+          }
+        },
+        "list_dimensions": null
+      }
+    ]
+  }
+}

--- a/packages/clarity/test/contract-interface-samples/non-fungible-token.json
+++ b/packages/clarity/test/contract-interface-samples/non-fungible-token.json
@@ -1,0 +1,517 @@
+{
+  "private_function_types": {
+    "balance-of": {
+      "Fixed": [
+        [
+          {
+            "atomic_type": "PrincipalType",
+            "list_dimensions": null,
+            "name": "account"
+          }
+        ],
+        {
+          "atomic_type": "IntType",
+          "list_dimensions": null
+        }
+      ]
+    },
+    "can-transfer": {
+      "Fixed": [
+        [
+          {
+            "atomic_type": "PrincipalType",
+            "list_dimensions": null,
+            "name": "actor"
+          },
+          {
+            "atomic_type": "IntType",
+            "list_dimensions": null,
+            "name": "token-id"
+          }
+        ],
+        {
+          "atomic_type": "BoolType",
+          "list_dimensions": null
+        }
+      ]
+    },
+    "is-operator-approved": {
+      "Fixed": [
+        [
+          {
+            "atomic_type": "PrincipalType",
+            "list_dimensions": null,
+            "name": "account"
+          },
+          {
+            "atomic_type": "PrincipalType",
+            "list_dimensions": null,
+            "name": "operator"
+          }
+        ],
+        {
+          "atomic_type": "BoolType",
+          "list_dimensions": null
+        }
+      ]
+    },
+    "is-owner": {
+      "Fixed": [
+        [
+          {
+            "atomic_type": "PrincipalType",
+            "list_dimensions": null,
+            "name": "actor"
+          },
+          {
+            "atomic_type": "IntType",
+            "list_dimensions": null,
+            "name": "token-id"
+          }
+        ],
+        {
+          "atomic_type": "BoolType",
+          "list_dimensions": null
+        }
+      ]
+    },
+    "is-spender-approved": {
+      "Fixed": [
+        [
+          {
+            "atomic_type": "PrincipalType",
+            "list_dimensions": null,
+            "name": "spender"
+          },
+          {
+            "atomic_type": "IntType",
+            "list_dimensions": null,
+            "name": "token-id"
+          }
+        ],
+        {
+          "atomic_type": "BoolType",
+          "list_dimensions": null
+        }
+      ]
+    },
+    "mint!": {
+      "Fixed": [
+        [
+          {
+            "atomic_type": "PrincipalType",
+            "list_dimensions": null,
+            "name": "owner"
+          },
+          {
+            "atomic_type": "IntType",
+            "list_dimensions": null,
+            "name": "token-id"
+          }
+        ],
+        {
+          "atomic_type": {
+            "ResponseType": [
+              {
+                "atomic_type": "IntType",
+                "list_dimensions": null
+              },
+              {
+                "atomic_type": "IntType",
+                "list_dimensions": null
+              }
+            ]
+          },
+          "list_dimensions": null
+        }
+      ]
+    },
+    "owner-of": {
+      "Fixed": [
+        [
+          {
+            "atomic_type": "IntType",
+            "list_dimensions": null,
+            "name": "token-id"
+          }
+        ],
+        {
+          "atomic_type": {
+            "OptionalType": {
+              "atomic_type": "PrincipalType",
+              "list_dimensions": null
+            }
+          },
+          "list_dimensions": null
+        }
+      ]
+    },
+    "register-token!": {
+      "Fixed": [
+        [
+          {
+            "atomic_type": "PrincipalType",
+            "list_dimensions": null,
+            "name": "new-owner"
+          },
+          {
+            "atomic_type": "IntType",
+            "list_dimensions": null,
+            "name": "token-id"
+          }
+        ],
+        {
+          "atomic_type": "BoolType",
+          "list_dimensions": null
+        }
+      ]
+    },
+    "release-token!": {
+      "Fixed": [
+        [
+          {
+            "atomic_type": "PrincipalType",
+            "list_dimensions": null,
+            "name": "owner"
+          },
+          {
+            "atomic_type": "IntType",
+            "list_dimensions": null,
+            "name": "token-id"
+          }
+        ],
+        {
+          "atomic_type": "BoolType",
+          "list_dimensions": null
+        }
+      ]
+    }
+  },
+  "variable_types": {
+    "failed-to-mint-err": {
+      "atomic_type": {
+        "ResponseType": [
+          {
+            "atomic_type": "NoType",
+            "list_dimensions": null
+          },
+          {
+            "atomic_type": "IntType",
+            "list_dimensions": null
+          }
+        ]
+      },
+      "list_dimensions": null
+    },
+    "failed-to-move-token-err": {
+      "atomic_type": {
+        "ResponseType": [
+          {
+            "atomic_type": "NoType",
+            "list_dimensions": null
+          },
+          {
+            "atomic_type": "IntType",
+            "list_dimensions": null
+          }
+        ]
+      },
+      "list_dimensions": null
+    },
+    "not-approved-spender-err": {
+      "atomic_type": {
+        "ResponseType": [
+          {
+            "atomic_type": "NoType",
+            "list_dimensions": null
+          },
+          {
+            "atomic_type": "IntType",
+            "list_dimensions": null
+          }
+        ]
+      },
+      "list_dimensions": null
+    },
+    "same-spender-err": {
+      "atomic_type": {
+        "ResponseType": [
+          {
+            "atomic_type": "NoType",
+            "list_dimensions": null
+          },
+          {
+            "atomic_type": "IntType",
+            "list_dimensions": null
+          }
+        ]
+      },
+      "list_dimensions": null
+    },
+    "unauthorized-transfer-err": {
+      "atomic_type": {
+        "ResponseType": [
+          {
+            "atomic_type": "NoType",
+            "list_dimensions": null
+          },
+          {
+            "atomic_type": "IntType",
+            "list_dimensions": null
+          }
+        ]
+      },
+      "list_dimensions": null
+    }
+  },
+  "public_function_types": {
+    "set-operator-approval": {
+      "Fixed": [
+        [
+          {
+            "atomic_type": "PrincipalType",
+            "list_dimensions": null,
+            "name": "operator"
+          },
+          {
+            "atomic_type": "BoolType",
+            "list_dimensions": null,
+            "name": "is-approved"
+          }
+        ],
+        {
+          "atomic_type": {
+            "ResponseType": [
+              {
+                "atomic_type": "BoolType",
+                "list_dimensions": null
+              },
+              {
+                "atomic_type": "IntType",
+                "list_dimensions": null
+              }
+            ]
+          },
+          "list_dimensions": null
+        }
+      ]
+    },
+    "set-spender-approval": {
+      "Fixed": [
+        [
+          {
+            "atomic_type": "PrincipalType",
+            "list_dimensions": null,
+            "name": "spender"
+          },
+          {
+            "atomic_type": "IntType",
+            "list_dimensions": null,
+            "name": "token-id"
+          }
+        ],
+        {
+          "atomic_type": {
+            "ResponseType": [
+              {
+                "atomic_type": "IntType",
+                "list_dimensions": null
+              },
+              {
+                "atomic_type": "IntType",
+                "list_dimensions": null
+              }
+            ]
+          },
+          "list_dimensions": null
+        }
+      ]
+    },
+    "transfer": {
+      "Fixed": [
+        [
+          {
+            "atomic_type": "PrincipalType",
+            "list_dimensions": null,
+            "name": "recipient"
+          },
+          {
+            "atomic_type": "IntType",
+            "list_dimensions": null,
+            "name": "token-id"
+          }
+        ],
+        {
+          "atomic_type": {
+            "ResponseType": [
+              {
+                "atomic_type": "IntType",
+                "list_dimensions": null
+              },
+              {
+                "atomic_type": "IntType",
+                "list_dimensions": null
+              }
+            ]
+          },
+          "list_dimensions": null
+        }
+      ]
+    },
+    "transfer-from": {
+      "Fixed": [
+        [
+          {
+            "atomic_type": "PrincipalType",
+            "list_dimensions": null,
+            "name": "owner"
+          },
+          {
+            "atomic_type": "PrincipalType",
+            "list_dimensions": null,
+            "name": "recipient"
+          },
+          {
+            "atomic_type": "IntType",
+            "list_dimensions": null,
+            "name": "token-id"
+          }
+        ],
+        {
+          "atomic_type": {
+            "ResponseType": [
+              {
+                "atomic_type": "IntType",
+                "list_dimensions": null
+              },
+              {
+                "atomic_type": "IntType",
+                "list_dimensions": null
+              }
+            ]
+          },
+          "list_dimensions": null
+        }
+      ]
+    }
+  },
+  "read_only_function_types": {},
+  "map_types": {
+    "accounts-operator": [
+      {
+        "atomic_type": {
+          "TupleType": {
+            "type_map": {
+              "account": {
+                "atomic_type": "PrincipalType",
+                "list_dimensions": null
+              },
+              "operator": {
+                "atomic_type": "PrincipalType",
+                "list_dimensions": null
+              }
+            }
+          }
+        },
+        "list_dimensions": null
+      },
+      {
+        "atomic_type": {
+          "TupleType": {
+            "type_map": {
+              "is-approved": {
+                "atomic_type": "BoolType",
+                "list_dimensions": null
+              }
+            }
+          }
+        },
+        "list_dimensions": null
+      }
+    ],
+    "tokens-count": [
+      {
+        "atomic_type": {
+          "TupleType": {
+            "type_map": {
+              "owner": {
+                "atomic_type": "PrincipalType",
+                "list_dimensions": null
+              }
+            }
+          }
+        },
+        "list_dimensions": null
+      },
+      {
+        "atomic_type": {
+          "TupleType": {
+            "type_map": {
+              "count": {
+                "atomic_type": "IntType",
+                "list_dimensions": null
+              }
+            }
+          }
+        },
+        "list_dimensions": null
+      }
+    ],
+    "tokens-owner": [
+      {
+        "atomic_type": {
+          "TupleType": {
+            "type_map": {
+              "token-id": {
+                "atomic_type": "IntType",
+                "list_dimensions": null
+              }
+            }
+          }
+        },
+        "list_dimensions": null
+      },
+      {
+        "atomic_type": {
+          "TupleType": {
+            "type_map": {
+              "owner": {
+                "atomic_type": "PrincipalType",
+                "list_dimensions": null
+              }
+            }
+          }
+        },
+        "list_dimensions": null
+      }
+    ],
+    "tokens-spender": [
+      {
+        "atomic_type": {
+          "TupleType": {
+            "type_map": {
+              "token-id": {
+                "atomic_type": "IntType",
+                "list_dimensions": null
+              }
+            }
+          }
+        },
+        "list_dimensions": null
+      },
+      {
+        "atomic_type": {
+          "TupleType": {
+            "type_map": {
+              "spender": {
+                "atomic_type": "PrincipalType",
+                "list_dimensions": null
+              }
+            }
+          }
+        },
+        "list_dimensions": null
+      }
+    ]
+  }
+}

--- a/packages/clarity/test/contract-interface-samples/tokens.json
+++ b/packages/clarity/test/contract-interface-samples/tokens.json
@@ -1,0 +1,147 @@
+{
+  "private_function_types": {
+    "get-balance": {
+      "Fixed": [
+        [
+          {
+            "atomic_type": "PrincipalType",
+            "list_dimensions": null,
+            "name": "account"
+          }
+        ],
+        {
+          "atomic_type": "IntType",
+          "list_dimensions": null
+        }
+      ]
+    },
+    "token-credit!": {
+      "Fixed": [
+        [
+          {
+            "atomic_type": "PrincipalType",
+            "list_dimensions": null,
+            "name": "account"
+          },
+          {
+            "atomic_type": "IntType",
+            "list_dimensions": null,
+            "name": "tokens"
+          }
+        ],
+        {
+          "atomic_type": {
+            "ResponseType": [
+              {
+                "atomic_type": "IntType",
+                "list_dimensions": null
+              },
+              {
+                "atomic_type": {
+                  "BufferType": 26
+                },
+                "list_dimensions": null
+              }
+            ]
+          },
+          "list_dimensions": null
+        }
+      ]
+    }
+  },
+  "variable_types": {},
+  "public_function_types": {
+    "mint!": {
+      "Fixed": [
+        [
+          {
+            "atomic_type": "IntType",
+            "list_dimensions": null,
+            "name": "amount"
+          }
+        ],
+        {
+          "atomic_type": {
+            "ResponseType": [
+              {
+                "atomic_type": "IntType",
+                "list_dimensions": null
+              },
+              {
+                "atomic_type": {
+                  "BufferType": 26
+                },
+                "list_dimensions": null
+              }
+            ]
+          },
+          "list_dimensions": null
+        }
+      ]
+    },
+    "token-transfer": {
+      "Fixed": [
+        [
+          {
+            "atomic_type": "PrincipalType",
+            "list_dimensions": null,
+            "name": "to"
+          },
+          {
+            "atomic_type": "IntType",
+            "list_dimensions": null,
+            "name": "amount"
+          }
+        ],
+        {
+          "atomic_type": {
+            "ResponseType": [
+              {
+                "atomic_type": "IntType",
+                "list_dimensions": null
+              },
+              {
+                "atomic_type": {
+                  "BufferType": 48
+                },
+                "list_dimensions": null
+              }
+            ]
+          },
+          "list_dimensions": null
+        }
+      ]
+    }
+  },
+  "read_only_function_types": {},
+  "map_types": {
+    "tokens": [
+      {
+        "atomic_type": {
+          "TupleType": {
+            "type_map": {
+              "account": {
+                "atomic_type": "PrincipalType",
+                "list_dimensions": null
+              }
+            }
+          }
+        },
+        "list_dimensions": null
+      },
+      {
+        "atomic_type": {
+          "TupleType": {
+            "type_map": {
+              "balance": {
+                "atomic_type": "IntType",
+                "list_dimensions": null
+              }
+            }
+          }
+        },
+        "list_dimensions": null
+      }
+    ]
+  }
+}

--- a/packages/clarity/test/contractInterfaceTests.ts
+++ b/packages/clarity/test/contractInterfaceTests.ts
@@ -30,22 +30,6 @@ describe("contract interface type checking", () => {
     nonFungibleToken = loadSampleContract("non-fungible-token.json");
   });
 
-  it("null const variable", () => {
-    // const exNullConst = typeTestContract.variable_types["example-null-const"];
-    // assert.equal(exNullConst.atomic_type, "VoidType");
-  });
-
-  it("null check function", () => {
-    // const getNullVarFn = typeTestContract.private_function_types["get-null-var"].Fixed;
-    // assert.equal(getNullVarFn[FunctionReturnType].atomic_type, "VoidType");
-  });
-
-  it("null arg input function", () => {
-    // const echoNullVarFn = typeTestContract.private_function_types["echo-null-var"].Fixed;
-    // assert.equal(echoNullVarFn[FunctionArgTypes][0].atomic_type, "VoidType");
-    // assert.equal(echoNullVarFn[FunctionReturnType].atomic_type, "VoidType");
-  });
-
   it("check private function types", () => {
     const priceFuncSig = namesContract.private_function_types["price-function"];
     assert.isOk(priceFuncSig.Fixed);

--- a/packages/clarity/test/contractInterfaceTests.ts
+++ b/packages/clarity/test/contractInterfaceTests.ts
@@ -1,0 +1,141 @@
+import { assert } from "chai";
+import * as fs from "fs";
+import * as path from "path";
+import {
+  ContractInterface,
+  FunctionArgTypes,
+  FunctionReturnType,
+  ResponseType,
+  ResponseTypeError,
+  ResponseTypeOk
+} from "../src/core/contractInterface";
+
+describe("contract interface type checking", () => {
+  let namesContract: ContractInterface;
+  let tokensContract: ContractInterface;
+  let nonFungibleToken: ContractInterface;
+
+  before(() => {
+    function loadSampleContract(file: string) {
+      const fileContent = fs.readFileSync(
+        path.join(__dirname, "contract-interface-samples", file),
+        { encoding: "utf8" }
+      );
+      const fileJson = JSON.parse(fileContent);
+      return fileJson as ContractInterface;
+    }
+
+    namesContract = loadSampleContract("names.json");
+    tokensContract = loadSampleContract("tokens.json");
+    nonFungibleToken = loadSampleContract("non-fungible-token.json");
+  });
+
+  it("null const variable", () => {
+    // const exNullConst = typeTestContract.variable_types["example-null-const"];
+    // assert.equal(exNullConst.atomic_type, "VoidType");
+  });
+
+  it("null check function", () => {
+    // const getNullVarFn = typeTestContract.private_function_types["get-null-var"].Fixed;
+    // assert.equal(getNullVarFn[FunctionReturnType].atomic_type, "VoidType");
+  });
+
+  it("null arg input function", () => {
+    // const echoNullVarFn = typeTestContract.private_function_types["echo-null-var"].Fixed;
+    // assert.equal(echoNullVarFn[FunctionArgTypes][0].atomic_type, "VoidType");
+    // assert.equal(echoNullVarFn[FunctionReturnType].atomic_type, "VoidType");
+  });
+
+  it("check private function types", () => {
+    const priceFuncSig = namesContract.private_function_types["price-function"];
+    assert.isOk(priceFuncSig.Fixed);
+    const priceFuncArgs = priceFuncSig.Fixed[FunctionArgTypes];
+    assert.equal(priceFuncArgs[0].atomic_type, "IntType");
+    const priceFuncReturnType = priceFuncSig.Fixed[FunctionReturnType];
+    assert.equal(priceFuncReturnType.atomic_type, "IntType");
+  });
+
+  it("check public function types", () => {
+    const preorderFuncSig = namesContract.public_function_types.preorder;
+    assert.isOk(preorderFuncSig.Fixed);
+    assert.deepEqual(preorderFuncSig.Fixed[FunctionArgTypes][0].atomic_type, {
+      BufferType: 20
+    });
+    assert.equal(preorderFuncSig.Fixed[FunctionArgTypes][1].atomic_type, "IntType");
+    const preorderFuncReturnType = preorderFuncSig.Fixed[FunctionReturnType]
+      .atomic_type as ResponseType;
+    assert.equal(preorderFuncReturnType.ResponseType[ResponseTypeOk].atomic_type, "IntType");
+    assert.deepEqual(preorderFuncReturnType.ResponseType[ResponseTypeError].atomic_type, {
+      BufferType: 21
+    });
+
+    const registerFuncSig = namesContract.public_function_types.register;
+    assert.isOk(registerFuncSig.Fixed);
+    assert.equal(registerFuncSig.Fixed[FunctionArgTypes][0].atomic_type, "PrincipalType");
+    assert.equal(registerFuncSig.Fixed[FunctionArgTypes][1].atomic_type, "IntType");
+    assert.equal(registerFuncSig.Fixed[FunctionArgTypes][2].atomic_type, "IntType");
+    const registerFuncReturnType = registerFuncSig.Fixed[FunctionReturnType]
+      .atomic_type as ResponseType;
+    assert.equal(registerFuncReturnType.ResponseType[ResponseTypeOk].atomic_type, "IntType");
+    assert.deepEqual(registerFuncReturnType.ResponseType[ResponseTypeError].atomic_type, {
+      BufferType: 31
+    });
+  });
+
+  it("check variable types", () => {
+    const burnAddressVarType = namesContract.variable_types["burn-address"];
+    assert.equal(burnAddressVarType.atomic_type, "PrincipalType");
+  });
+
+  it("check map types", () => {
+    const nameMap = namesContract.map_types["name-map"];
+    assert.deepEqual(nameMap[0].atomic_type, {
+      TupleType: {
+        type_map: {
+          name: {
+            atomic_type: "IntType",
+            list_dimensions: null
+          }
+        }
+      }
+    });
+    assert.deepEqual(nameMap[1].atomic_type, {
+      TupleType: {
+        type_map: {
+          owner: {
+            atomic_type: "PrincipalType",
+            list_dimensions: null
+          }
+        }
+      }
+    });
+
+    const preorderMap = namesContract.map_types["preorder-map"];
+    assert.deepEqual(preorderMap[0].atomic_type, {
+      TupleType: {
+        type_map: {
+          "name-hash": {
+            atomic_type: {
+              BufferType: 20
+            },
+            list_dimensions: null
+          }
+        }
+      }
+    });
+    assert.deepEqual(preorderMap[1].atomic_type, {
+      TupleType: {
+        type_map: {
+          buyer: {
+            atomic_type: "PrincipalType",
+            list_dimensions: null
+          },
+          paid: {
+            atomic_type: "IntType",
+            list_dimensions: null
+          }
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
Added the new `Optional` and `Response` types to the contract interface.

Note that the top level `ContractInterface` type definition still mirrors the current serialized `ContractAnalysis` rust struct. It will be updated to an explicit struct when a PR for this issue is ready https://github.com/blockstack/blockstack-core/issues/1015