### PR TITLE
Expanded result type guards

### DIFF
--- a/packages/clarity-tutorials/src/clients/rocketTutorial/rocketFactory.ts
+++ b/packages/clarity-tutorials/src/clients/rocketTutorial/rocketFactory.ts
@@ -19,7 +19,7 @@ export class RocketFactoryClient extends Client {
   async rocketClaimableAt(user: string): Promise<number> {
     const query = this.createQuery({ method: { name: "rocket-claimable-at", args: [`'${user}`] } });
     const res = await this.submitQuery(query);
-    return parseInt(Result.get(res));
+    return parseInt(Result.unwrap(res));
   }
 
   async orderRocket(size: number, params: { sender: string }): Promise<Receipt> {

--- a/packages/clarity-tutorials/src/clients/rocketTutorial/rocketMarket.ts
+++ b/packages/clarity-tutorials/src/clients/rocketTutorial/rocketMarket.ts
@@ -7,13 +7,13 @@ export class RocketMarketClient extends Client {
   async balanceOf(owner: string): Promise<number> {
     const query = this.createQuery({ method: { name: "balance-of", args: [`'${owner}`] } });
     const res = await this.submitQuery(query);
-    return parseInt(Result.get(res));
+    return parseInt(Result.unwrap(res));
   }
 
   async ownerOf(tokenId: number): Promise<string> {
     const query = this.createQuery({ method: { name: "owner-of", args: [`${tokenId}`] } });
     const res = await this.submitQuery(query);
-    return Result.get(res).replace(/'/g, "");
+    return Result.unwrap(res).replace(/'/g, "");
   }
 
   async transfer(to: string, tokenId: number, params: { sender: string }): Promise<Receipt> {

--- a/packages/clarity-tutorials/src/clients/rocketTutorial/rocketToken.ts
+++ b/packages/clarity-tutorials/src/clients/rocketTutorial/rocketToken.ts
@@ -16,12 +16,12 @@ export class RocketTokenClient extends Client {
   async balanceOf(owner: string): Promise<number> {
     const query = this.createQuery({ method: { name: "balance-of", args: [`'${owner}`] } });
     const res = await this.submitQuery(query);
-    return parseInt(Result.get(res));
+    return parseInt(Result.unwrap(res));
   }
 
   async totalSupply(): Promise<number> {
     const query = this.createQuery({ method: { name: "get-total-supply", args: [] } });
     const res = await this.submitQuery(query);
-    return parseInt(Result.get(res));
+    return parseInt(Result.unwrap(res));
   }
 }

--- a/packages/clarity-tutorials/src/clients/tokens/fungibleToken.ts
+++ b/packages/clarity-tutorials/src/clients/tokens/fungibleToken.ts
@@ -16,7 +16,7 @@ export class FungibleTokenClient extends Client {
   async balanceOf(owner: string): Promise<number> {
     const query = this.createQuery({ method: { name: "balance-of", args: [`'${owner}`] } });
     const res = await this.submitQuery(query);
-    return parseInt(Result.get(res));
+    return parseInt(Result.unwrap(res));
   }
 
   async approve(spender: string, amount: number, params: { sender: string }): Promise<Receipt> {
@@ -40,7 +40,7 @@ export class FungibleTokenClient extends Client {
       method: { name: "allowance-of", args: [`'${spender}`, `'${owner}`] }
     });
     const res = await this.submitQuery(query);
-    return parseInt(Result.get(res));
+    return parseInt(Result.unwrap(res));
   }
 
   async transferFrom(

--- a/packages/clarity-tutorials/src/clients/tokens/nonFungibleToken.ts
+++ b/packages/clarity-tutorials/src/clients/tokens/nonFungibleToken.ts
@@ -7,13 +7,13 @@ export class NonFungibleTokenClient extends Client {
   async balanceOf(owner: string): Promise<number> {
     const query = this.createQuery({ method: { name: "balance-of", args: [`'${owner}`] } });
     const res = await this.submitQuery(query);
-    return parseInt(Result.get(res));
+    return parseInt(Result.unwrap(res));
   }
 
   async ownerOf(tokenId: number): Promise<string> {
     const query = this.createQuery({ method: { name: "owner-of", args: [`${tokenId}`] } });
     const res = await this.submitQuery(query);
-    return Result.get(res).replace(/'/g, "");
+    return Result.unwrap(res).replace(/'/g, "");
   }
 
   async canTransfer(actor: string, tokenId: number): Promise<boolean> {
@@ -21,7 +21,7 @@ export class NonFungibleTokenClient extends Client {
       method: { name: "can-transfer", args: [`'${actor}`, `${tokenId}`] }
     });
     const res = await this.submitQuery(query);
-    return Result.get(res).replace(/'/g, "") === "true";
+    return Result.unwrap(res).replace(/'/g, "") === "true";
   }
 
   async isSpenderApproved(spender: string, tokenId: number): Promise<number> {
@@ -29,7 +29,7 @@ export class NonFungibleTokenClient extends Client {
       method: { name: "is-spender-approved", args: [`'${spender}`, `${tokenId}`] }
     });
     const res = await this.submitQuery(query);
-    return parseInt(Result.get(res));
+    return parseInt(Result.unwrap(res));
   }
 
   async isOperatorApproved(owner: string, operator: string): Promise<number> {
@@ -37,7 +37,7 @@ export class NonFungibleTokenClient extends Client {
       method: { name: "is-operator-approved", args: [`'${owner}`, `'${operator}`] }
     });
     const res = await this.submitQuery(query);
-    return parseInt(Result.get(res));
+    return parseInt(Result.unwrap(res));
   }
 
   async setSpenderApproval(


### PR DESCRIPTION
Related to https://github.com/blockstack/clarity-js-sdk/pull/22#discussion_r293586509

* Provide `match` function for objects defining a result-like interface.
* Improve error handling in result `unwrap` function.