### PR TITLE
Improve dev-project generator dev-ux for release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,9 @@ tsconfig.tsbuildinfo
 oclif.manifest.json
 package.json.lerna_backup
 *.native-bin
+packages/generator-clarity-dev/generators/index.*
 packages/generator-clarity-dev/generators/app/index.*
+packages/generator-clarity-dev/generators/modularGen.*
 .yo-test*
 .blockstack-core-src
+

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -51,7 +51,8 @@
       "name": "clarity-cli: test",
       "program": "${workspaceFolder}/packages/clarity-cli/node_modules/mocha/bin/_mocha",
       "cwd": "${workspaceFolder}/packages/clarity-cli",
-      "console": "integratedTerminal"
+      "console": "integratedTerminal",
+      "preLaunchTask": "npm: build"
     },
     {
       "type": "node",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -75,7 +75,8 @@
       "name": "generator-clarity-dev: test",
       "program": "${workspaceFolder}/packages/generator-clarity-dev/node_modules/mocha/bin/_mocha",
       "cwd": "${workspaceFolder}/packages/generator-clarity-dev",
-      "console": "integratedTerminal"
+      "console": "integratedTerminal",
+      "preLaunchTask": "npm: build"
     }
   ]
 }

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.1.5-alpha.0"
+  "version": "0.1.6-alpha.0"
 }

--- a/packages/clarity-cli/README.md
+++ b/packages/clarity-cli/README.md
@@ -10,7 +10,7 @@ $ npm install -g @blockstack/clarity-cli
 $ clarity COMMAND
 running command...
 $ clarity (-v|--version|version)
-@blockstack/clarity-cli/0.1.5-alpha.0 darwin-x64 node-v10.15.3
+@blockstack/clarity-cli/0.1.6-alpha.0 darwin-x64 node-v10.15.3
 $ clarity --help [COMMAND]
 USAGE
   $ clarity COMMAND
@@ -20,7 +20,7 @@ USAGE
 # Commands
 <!-- commands -->
 * [`clarity help [COMMAND]`](#clarity-help-command)
-* [`clarity new [PROJECT]`](#clarity-new-project)
+* [`clarity new PROJECT`](#clarity-new-project)
 * [`clarity setup`](#clarity-setup)
 
 ## `clarity help [COMMAND]`
@@ -40,16 +40,17 @@ OPTIONS
 
 _See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v2.2.0/src/commands/help.ts)_
 
-## `clarity new [PROJECT]`
+## `clarity new PROJECT`
 
 Generate new project
 
 ```
 USAGE
-  $ clarity new [PROJECT]
+  $ clarity new PROJECT
 
 OPTIONS
-  -h, --help  show CLI help
+  -h, --help      show CLI help
+  --skip_install  Skip running `npm install` after project generation.
 
 EXAMPLE
   $ clarity new <PROJECT_NAME>

--- a/packages/clarity-cli/package-lock.json
+++ b/packages/clarity-cli/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockstack/clarity-cli",
-	"version": "0.1.3-alpha.0",
+	"version": "0.1.5-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/clarity-cli/package.json
+++ b/packages/clarity-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockstack/clarity-cli",
-  "version": "0.1.5-alpha.0",
+  "version": "0.1.6-alpha.0",
   "description": "The Clarity CLI is used to manage Clarity smart contracts from the command line.",
   "author": "Blockstack <engineering@blockstack.com> (https://blockstack.com/)",
   "license": "MIT",
@@ -45,13 +45,13 @@
     "test": "npm run build && nyc mocha"
   },
   "dependencies": {
-    "@blockstack/clarity": "^0.1.5-alpha.0",
-    "@blockstack/clarity-native-bin": "^0.1.4-alpha.0",
-    "generator-clarity-dev": "^0.1.5-alpha.0",
+    "@blockstack/clarity": "^0.1.6-alpha.0",
+    "@blockstack/clarity-native-bin": "^0.1.6-alpha.0",
     "@oclif/command": "^1.5.13",
     "@oclif/config": "^1.13.0",
     "@oclif/plugin-help": "^2.1.6",
     "fs-extra": "^8.0.1",
+    "generator-clarity-dev": "^0.1.6-alpha.0",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/packages/clarity-cli/package.json
+++ b/packages/clarity-cli/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "@blockstack/clarity": "^0.1.5-alpha.0",
     "@blockstack/clarity-native-bin": "^0.1.4-alpha.0",
+    "generator-clarity-dev": "^0.1.5-alpha.0",
     "@oclif/command": "^1.5.13",
     "@oclif/config": "^1.13.0",
     "@oclif/plugin-help": "^2.1.6",

--- a/packages/clarity-cli/src/commands/new.ts
+++ b/packages/clarity-cli/src/commands/new.ts
@@ -1,18 +1,29 @@
 import { Command, flags } from "@oclif/command";
-
+import * as AppGenerator from "generator-clarity-dev";
 export default class New extends Command {
   static description = "Generate new project";
 
   static examples = [`$ clarity new <PROJECT_NAME>`];
 
   static flags = {
-    help: flags.help({ char: "h" })
+    help: flags.help({ char: "h" }),
+    skip_install: flags.boolean({
+      default: false,
+      description: "Skip running `npm install` after project generation."
+    })
   };
 
-  static args = [{ name: "project" }];
+  static args = [{ name: "project", required: true }];
 
   async run() {
     const { args, flags } = this.parse(New);
-    this.log("todo " + (args.project || ""));
+
+    const createAppGenOpts = {
+      "skip-install": flags.skip_install
+    };
+
+    const projName = args.project;
+    const appGen = AppGenerator.createAppGen({ args: [projName], options: createAppGenOpts });
+    await appGen.run();
   }
 }

--- a/packages/clarity-cli/test/commands/new.test.ts
+++ b/packages/clarity-cli/test/commands/new.test.ts
@@ -1,17 +1,20 @@
 import { expect, test } from "@oclif/test";
+import fs from "fs-extra";
+import os from "os";
+import path from "path";
 
 describe("new project", () => {
+  const testingDir = path.resolve(path.join(path.dirname(__dirname), ".yo-test"));
+  fs.mkdirSync(testingDir, { recursive: true });
+  const outputDir = fs.mkdtempSync(`${testingDir}${path.sep}`);
   test
     .stdout()
-    .command(["new"])
-    .it("runs new", ctx => {
-      expect(ctx.stdout).to.contain("todo");
-    });
-
-  test
-    .stdout()
-    .command(["new", "example_proj"])
-    .it("runs new example_proj", ctx => {
-      expect(ctx.stdout).to.contain("todo example_proj");
+    .command(["new", outputDir, "--skip_install"])
+    .finally(ctx => {
+      fs.removeSync(testingDir);
+    })
+    .it("runs new project", ctx => {
+      // tslint:disable-next-line: no-unused-expression
+      expect(ctx.error).to.be.undefined;
     });
 });

--- a/packages/clarity-cli/tsconfig.build.json
+++ b/packages/clarity-cli/tsconfig.build.json
@@ -12,6 +12,9 @@
     },
     {
       "path": "../clarity-native-bin/tsconfig.build.json"
+    },
+    {
+      "path": "../generator-clarity-dev/tsconfig.build.json"
     }
   ],
   "include": [

--- a/packages/clarity-native-bin/package-lock.json
+++ b/packages/clarity-native-bin/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockstack/clarity-native-bin",
-	"version": "0.1.3-alpha.0",
+	"version": "0.1.4-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -148,6 +148,12 @@
 			"requires": {
 				"@types/node": "*"
 			}
+		},
+		"@types/semver": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.0.1.tgz",
+			"integrity": "sha512-ffCdcrEE5h8DqVxinQjo+2d1q+FV5z7iNtPofw3JsrltSoSVlOGaW0rY8XxtO9XukdTn8TaCGWmk2VFGhI70mg==",
+			"dev": true
 		},
 		"@types/tar": {
 			"version": "4.0.0",
@@ -397,6 +403,14 @@
 				"semver": "^5.5.0",
 				"shebang-command": "^1.2.0",
 				"which": "^1.2.9"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
+				}
 			}
 		},
 		"debug": {
@@ -1034,6 +1048,14 @@
 			"requires": {
 				"pify": "^4.0.1",
 				"semver": "^5.6.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
+				}
 			}
 		},
 		"make-error": {
@@ -1187,6 +1209,14 @@
 			"requires": {
 				"object.getownpropertydescriptors": "^2.0.3",
 				"semver": "^5.7.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
+				}
 			}
 		},
 		"node-fetch": {
@@ -1204,6 +1234,14 @@
 				"resolve": "^1.10.0",
 				"semver": "2 || 3 || 4 || 5",
 				"validate-npm-package-license": "^3.0.1"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
+				}
 			}
 		},
 		"npm-run-path": {
@@ -1541,10 +1579,9 @@
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"semver": {
-			"version": "5.7.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-			"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-			"dev": true
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz",
+			"integrity": "sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ=="
 		},
 		"set-blocking": {
 			"version": "2.0.0",
@@ -1809,6 +1846,14 @@
 				"semver": "^5.3.0",
 				"tslib": "^1.8.0",
 				"tsutils": "^2.29.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
+				}
 			}
 		},
 		"tsutils": {

--- a/packages/clarity-native-bin/package.json
+++ b/packages/clarity-native-bin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockstack/clarity-native-bin",
-  "version": "0.1.4-alpha.0",
+  "version": "0.1.6-alpha.0",
   "description": "Library for providing the native Clarity CLI binary",
   "author": "Blockstack <engineering@blockstack.com> (https://blockstack.com/)",
   "license": "MIT",

--- a/packages/clarity-native-bin/package.json
+++ b/packages/clarity-native-bin/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "node-fetch": "^2.6.0",
+    "semver": "^6.1.1",
     "tar": "^4.4.8"
   },
   "devDependencies": {
@@ -38,6 +39,7 @@
     "@types/mocha": "^5.2.7",
     "@types/node": "^10",
     "@types/node-fetch": "^2.3.4",
+    "@types/semver": "^6.0.1",
     "@types/tar": "^4.0.0",
     "chai": "^4.2.0",
     "mocha": "^6.1.4",

--- a/packages/clarity-native-bin/postInstallScript.js
+++ b/packages/clarity-native-bin/postInstallScript.js
@@ -1,5 +1,17 @@
 const fs = require("fs");
 const path = require("path");
+const semver = require("semver");
+const generatorPackage = require(path.join(__dirname, "package.json"));
+
+const version = generatorPackage.engines.node;
+if (!semver.satisfies(process.version, version)) {
+  console.error(
+    `Node.js version ${version} is required. Installed version ${
+      process.version
+    } is not compatible.`
+  );
+  process.exit(1);
+}
 
 // Detect if running in dev environment.
 const tsConfigBuildFile = path.join(__dirname, "tsconfig.build.json");

--- a/packages/clarity-tslint/package-lock.json
+++ b/packages/clarity-tslint/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockstack/clarity-tslint",
-	"version": "0.1.3-alpha.0",
+	"version": "0.1.4-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/clarity-tslint/package.json
+++ b/packages/clarity-tslint/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@blockstack/clarity-tslint",
   "description": "tslint rules for blockstack",
-  "version": "0.1.4-alpha.0",
+  "version": "0.1.6-alpha.0",
   "author": "Blockstack <engineering@blockstack.com> (https://blockstack.com/)",
   "devDependencies": {
     "prettier": "1.17.1",

--- a/packages/clarity-tutorials/contracts/samples/hello-world.clar
+++ b/packages/clarity-tutorials/contracts/samples/hello-world.clar
@@ -1,5 +1,5 @@
 (define (hello-world)
-   (begin "hello world"))
+   "hello world")
 
 (define (echo-number (val int))
-   (begin val))
+   val)

--- a/packages/clarity-tutorials/package-lock.json
+++ b/packages/clarity-tutorials/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockstack/clarity-tutorials",
-	"version": "0.1.3-alpha.0",
+	"version": "0.1.5-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/clarity-tutorials/package.json
+++ b/packages/clarity-tutorials/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockstack/clarity-tutorials",
-  "version": "0.1.5-alpha.0",
+  "version": "0.1.6-alpha.0",
   "description": "Getting started with Clarity",
   "author": "Blockstack <engineering@blockstack.com> (https://blockstack.com/)",
   "license": "MIT",
@@ -28,8 +28,8 @@
     "/contracts"
   ],
   "dependencies": {
-    "@blockstack/clarity": "^0.1.5-alpha.0",
-    "@blockstack/clarity-native-bin": "^0.1.4-alpha.0"
+    "@blockstack/clarity": "^0.1.6-alpha.0",
+    "@blockstack/clarity-native-bin": "^0.1.6-alpha.0"
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",

--- a/packages/clarity/package-lock.json
+++ b/packages/clarity/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockstack/clarity",
-	"version": "0.1.3-alpha.0",
+	"version": "0.1.5-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/clarity/package.json
+++ b/packages/clarity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockstack/clarity",
-  "version": "0.1.5-alpha.0",
+  "version": "0.1.6-alpha.0",
   "description": "Clarity JS SDK - Core library",
   "author": "Blockstack <engineering@blockstack.com> (https://blockstack.com/)",
   "license": "MIT",
@@ -31,7 +31,7 @@
     "@blockstack/clarity-native-bin": "^0.1.4-alpha.0"
   },
   "devDependencies": {
-    "@blockstack/clarity-native-bin": "^0.1.4-alpha.0",
+    "@blockstack/clarity-native-bin": "^0.1.6-alpha.0",
     "@types/chai": "^4.1.7",
     "@types/mocha": "^5.2.7",
     "@types/node": "^10",

--- a/packages/generator-clarity-dev/README.md
+++ b/packages/generator-clarity-dev/README.md
@@ -42,13 +42,23 @@ _Expected output:_
 
 #### Project Generator
 
-The above `npm init ...` command uses the [`create-yo`](https://github.com/boneskull/create-yo) utility to avoid global package installs.
+* Ensure all checks pass when running `npx yo doctor`.
+  > ```
+  > Yeoman Doctor - Running sanity checks on your system
+  > ✔ Global configuration file is valid
+  > ✔ NODE_PATH matches the npm root
+  > ✔ Node.js version
+  > ✔ No .bowerrc file in home directory
+  > ✔ No .yo-rc.json file in home directory
+  > ✔ npm version
+  > ✔ yo version
 
-If running into problems then try with regular `yo` installation:
-```
-npm install -g yo generator-clarity-dev
-yo clarity-dev
-```
+* Alternate install commands
+  > The above `npm init ...` command uses the [`create-yo`](https://github.com/boneskull/create-yo) utility to avoid global package installs. If running into problems then try with regular `yo` installation:
+  > ```
+  > npm install -g yo generator-clarity-dev
+  > yo clarity-dev
+  > ```
 
 #### clarity-native-bin
 

--- a/packages/generator-clarity-dev/generators/app/templates/_package.json
+++ b/packages/generator-clarity-dev/generators/app/templates/_package.json
@@ -1,7 +1,17 @@
 {
+  "name": "<%= name %>",
+  "version": "0.0.0",
+  "author": {
+    "name": "<%= authorName %>",
+    "email": "<%= authorEmail %>"
+  },
+  "repository": "<%= repository %>",
   "private": true,
   "engines": {
     "node": ">=10"
+  },
+  "scripts": {
+    "test": "mocha"
   },
   "devDependencies": {
     "@types/node": "^10"

--- a/packages/generator-clarity-dev/generators/app/templates/contracts/sample/hello-world.clar
+++ b/packages/generator-clarity-dev/generators/app/templates/contracts/sample/hello-world.clar
@@ -1,5 +1,5 @@
 (define (hello-world)
-   (begin "hello world"))
+   "hello world")
 
 (define (echo-number (val int))
-   (begin val))
+   val)

--- a/packages/generator-clarity-dev/package-lock.json
+++ b/packages/generator-clarity-dev/package-lock.json
@@ -128,8 +128,7 @@
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
-      "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
-      "dev": true
+      "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
     },
     "@sinonjs/commons": {
       "version": "1.4.0",
@@ -179,7 +178,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
       "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
-      "dev": true,
       "requires": {
         "defer-to-connect": "^1.0.1"
       }
@@ -590,7 +588,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
       "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
-      "dev": true,
       "requires": {
         "clone-response": "^1.0.2",
         "get-stream": "^5.1.0",
@@ -605,7 +602,6 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
           "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
-          "dev": true,
           "requires": {
             "pump": "^3.0.0"
           }
@@ -613,8 +609,7 @@
         "lowercase-keys": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-          "dev": true
+          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
         }
       }
     },
@@ -768,7 +763,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
       "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
-      "dev": true,
       "requires": {
         "mimic-response": "^1.0.0"
       }
@@ -978,7 +972,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-      "dev": true,
       "requires": {
         "mimic-response": "^1.0.0"
       }
@@ -1017,8 +1010,7 @@
     "defer-to-connect": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.0.2.tgz",
-      "integrity": "sha512-k09hcQcTDY+cwgiwa6PYKLm3jlagNzQ+RSvhjzESOGOx+MNOuXkxTfEvPrO1IOQ81tArCFYQgi631clB70RpQw==",
-      "dev": true
+      "integrity": "sha512-k09hcQcTDY+cwgiwa6PYKLm3jlagNzQ+RSvhjzESOGOx+MNOuXkxTfEvPrO1IOQ81tArCFYQgi631clB70RpQw=="
     },
     "define-properties": {
       "version": "1.1.3",
@@ -1120,7 +1112,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -1577,20 +1568,19 @@
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
     },
     "gh-got": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/gh-got/-/gh-got-5.0.0.tgz",
-      "integrity": "sha1-7pW+NxBv2HSKlvjR20uuqJ4b+oo=",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/gh-got/-/gh-got-8.1.0.tgz",
+      "integrity": "sha512-Jy7+73XqsAVeAtM5zA0dd+A7mmzkQVIzFuw3xRjFbPsQVqS+aeci8v8H1heOCAPlBYWED5ZYPhlYqZVXdD3Fmg==",
       "requires": {
-        "got": "^6.2.0",
-        "is-plain-obj": "^1.1.0"
+        "got": "^9.5.0"
       }
     },
     "github-username": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/github-username/-/github-username-3.0.0.tgz",
-      "integrity": "sha1-CnciGbMTB0NCnyRW0L3T21Xc57E=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/github-username/-/github-username-5.0.1.tgz",
+      "integrity": "sha512-HxFIz5tIQDoiob2ienSKLHoCSFFC6F79IcnM5E5KNAxkxMjvpuUSE7K4fU2n51fwo0idT0ZsMFZIUy4SIPXoVA==",
       "requires": {
-        "gh-got": "^5.0.0"
+        "gh-got": "^8.1.0"
       }
     },
     "glob": {
@@ -1652,21 +1642,44 @@
       }
     },
     "got": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
-      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+      "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
       "requires": {
-        "create-error-class": "^3.0.0",
+        "@sindresorhus/is": "^0.14.0",
+        "@szmarczak/http-timer": "^1.1.2",
+        "cacheable-request": "^6.0.0",
+        "decompress-response": "^3.3.0",
         "duplexer3": "^0.1.4",
-        "get-stream": "^3.0.0",
-        "is-redirect": "^1.0.0",
-        "is-retry-allowed": "^1.0.0",
-        "is-stream": "^1.0.0",
-        "lowercase-keys": "^1.0.0",
-        "safe-buffer": "^5.0.1",
-        "timed-out": "^4.0.0",
-        "unzip-response": "^2.0.1",
-        "url-parse-lax": "^1.0.0"
+        "get-stream": "^4.1.0",
+        "lowercase-keys": "^1.0.1",
+        "mimic-response": "^1.0.1",
+        "p-cancelable": "^1.0.0",
+        "to-readable-stream": "^1.0.0",
+        "url-parse-lax": "^3.0.0"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "prepend-http": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+          "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
+        },
+        "url-parse-lax": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+          "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+          "requires": {
+            "prepend-http": "^2.0.0"
+          }
+        }
       }
     },
     "graceful-fs": {
@@ -1795,8 +1808,7 @@
     "http-cache-semantics": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
-      "integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew==",
-      "dev": true
+      "integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew=="
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -2265,8 +2277,7 @@
     "json-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
-      "dev": true
+      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -2283,7 +2294,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
       "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
-      "dev": true,
       "requires": {
         "json-buffer": "3.0.0"
       }
@@ -2581,8 +2591,7 @@
     "mimic-response": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-      "dev": true
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -2826,8 +2835,7 @@
     "normalize-url": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.3.0.tgz",
-      "integrity": "sha512-0NLtR71o4k6GLP+mr6Ty34c5GA6CMoEsncKJxvQd8NzPxaHRJNnb5gZE8R1XF4CPIS7QPHLJ74IFszwtNVAHVQ==",
-      "dev": true
+      "integrity": "sha512-0NLtR71o4k6GLP+mr6Ty34c5GA6CMoEsncKJxvQd8NzPxaHRJNnb5gZE8R1XF4CPIS7QPHLJ74IFszwtNVAHVQ=="
     },
     "npm-run-path": {
       "version": "2.0.2",
@@ -3028,8 +3036,7 @@
     "p-cancelable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
-      "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
-      "dev": true
+      "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
     },
     "p-defer": {
       "version": "1.0.0",
@@ -3287,7 +3294,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -3444,7 +3450,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
       "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
-      "dev": true,
       "requires": {
         "lowercase-keys": "^1.0.0"
       }
@@ -4001,8 +4006,7 @@
     "to-readable-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
-      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
-      "dev": true
+      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q=="
     },
     "to-regex": {
       "version": "3.0.2",
@@ -4661,6 +4665,43 @@
         "text-table": "^0.2.0",
         "through2": "^3.0.1",
         "yeoman-environment": "^2.3.4"
+      },
+      "dependencies": {
+        "gh-got": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/gh-got/-/gh-got-5.0.0.tgz",
+          "integrity": "sha1-7pW+NxBv2HSKlvjR20uuqJ4b+oo=",
+          "requires": {
+            "got": "^6.2.0",
+            "is-plain-obj": "^1.1.0"
+          }
+        },
+        "github-username": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/github-username/-/github-username-3.0.0.tgz",
+          "integrity": "sha1-CnciGbMTB0NCnyRW0L3T21Xc57E=",
+          "requires": {
+            "gh-got": "^5.0.0"
+          }
+        },
+        "got": {
+          "version": "6.7.1",
+          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+          "requires": {
+            "create-error-class": "^3.0.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "is-redirect": "^1.0.0",
+            "is-retry-allowed": "^1.0.0",
+            "is-stream": "^1.0.0",
+            "lowercase-keys": "^1.0.0",
+            "safe-buffer": "^5.0.1",
+            "timed-out": "^4.0.0",
+            "unzip-response": "^2.0.1",
+            "url-parse-lax": "^1.0.0"
+          }
+        }
       }
     },
     "yeoman-test": {

--- a/packages/generator-clarity-dev/package-lock.json
+++ b/packages/generator-clarity-dev/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-clarity-dev",
-  "version": "0.1.3-alpha.0",
+  "version": "0.1.5-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -245,6 +245,12 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA=="
+    },
+    "@types/semver": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.0.1.tgz",
+      "integrity": "sha512-ffCdcrEE5h8DqVxinQjo+2d1q+FV5z7iNtPofw3JsrltSoSVlOGaW0rY8XxtO9XukdTn8TaCGWmk2VFGhI70mg==",
+      "dev": true
     },
     "@types/through": {
       "version": "0.0.29",
@@ -632,6 +638,14 @@
           "requires": {
             "pify": "^4.0.1",
             "semver": "^5.6.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+              "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+              "dev": true
+            }
           }
         }
       }
@@ -892,6 +906,14 @@
           "requires": {
             "pify": "^4.0.1",
             "semver": "^5.6.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+              "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+              "dev": true
+            }
           }
         }
       }
@@ -914,6 +936,13 @@
         "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+        }
       }
     },
     "dargs": {
@@ -1067,6 +1096,13 @@
       "requires": {
         "errlop": "^1.1.1",
         "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+        }
       }
     },
     "ejs": {
@@ -1388,6 +1424,14 @@
           "requires": {
             "pify": "^4.0.1",
             "semver": "^5.6.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+              "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+              "dev": true
+            }
           }
         }
       }
@@ -2092,6 +2136,14 @@
           "requires": {
             "pify": "^4.0.1",
             "semver": "^5.6.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+              "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+              "dev": true
+            }
           }
         },
         "supports-color": {
@@ -2126,6 +2178,14 @@
           "requires": {
             "pify": "^4.0.1",
             "semver": "^5.6.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+              "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+              "dev": true
+            }
           }
         },
         "source-map": {
@@ -2720,6 +2780,14 @@
       "requires": {
         "object.getownpropertydescriptors": "^2.0.3",
         "semver": "^5.7.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
       }
     },
     "normalize-package-data": {
@@ -2731,6 +2799,13 @@
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+        }
       }
     },
     "normalize-url": {
@@ -2795,6 +2870,14 @@
           "requires": {
             "pify": "^4.0.1",
             "semver": "^5.6.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+              "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+              "dev": true
+            }
           }
         }
       }
@@ -3413,9 +3496,9 @@
       "integrity": "sha1-o0a7Gs1CB65wvXwMfKnlZra63bg="
     },
     "semver": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz",
+      "integrity": "sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ=="
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -3969,6 +4052,14 @@
         "semver": "^5.3.0",
         "tslib": "^1.8.0",
         "tsutils": "^2.29.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
       }
     },
     "tsutils": {

--- a/packages/generator-clarity-dev/package-lock.json
+++ b/packages/generator-clarity-dev/package-lock.json
@@ -1384,6 +1384,21 @@
         "escape-string-regexp": "^1.0.5"
       }
     },
+    "filename-reserved-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+      "integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik="
+    },
+    "filenamify": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.1.0.tgz",
+      "integrity": "sha512-KQV/uJDI9VQgN7sHH1Zbk6+42cD6mnQ2HONzkXUfPJ+K2FC8GZ1dpewbbHw0Sz8Tf5k3EVdHVayM4DoAwWlmtg==",
+      "requires": {
+        "filename-reserved-regex": "^2.0.0",
+        "strip-outer": "^1.0.1",
+        "trim-repeated": "^1.0.0"
+      }
+    },
     "fill-range": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -3872,6 +3887,14 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
+    "strip-outer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+      "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+      "requires": {
+        "escape-string-regexp": "^1.0.2"
+      }
+    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -3999,6 +4022,14 @@
       "requires": {
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
+      }
+    },
+    "trim-repeated": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+      "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
+      "requires": {
+        "escape-string-regexp": "^1.0.2"
       }
     },
     "trim-right": {

--- a/packages/generator-clarity-dev/package-lock.json
+++ b/packages/generator-clarity-dev/package-lock.json
@@ -1375,21 +1375,6 @@
         "escape-string-regexp": "^1.0.5"
       }
     },
-    "filename-reserved-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
-      "integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik="
-    },
-    "filenamify": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.1.0.tgz",
-      "integrity": "sha512-KQV/uJDI9VQgN7sHH1Zbk6+42cD6mnQ2HONzkXUfPJ+K2FC8GZ1dpewbbHw0Sz8Tf5k3EVdHVayM4DoAwWlmtg==",
-      "requires": {
-        "filename-reserved-regex": "^2.0.0",
-        "strip-outer": "^1.0.1",
-        "trim-repeated": "^1.0.0"
-      }
-    },
     "fill-range": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -3892,14 +3877,6 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
-    "strip-outer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
-      "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
-      "requires": {
-        "escape-string-regexp": "^1.0.2"
-      }
-    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -4026,14 +4003,6 @@
       "requires": {
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
-      }
-    },
-    "trim-repeated": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
-      "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
-      "requires": {
-        "escape-string-regexp": "^1.0.2"
       }
     },
     "trim-right": {

--- a/packages/generator-clarity-dev/package.json
+++ b/packages/generator-clarity-dev/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@blockstack/clarity": "^0.1.5-alpha.0",
     "@blockstack/clarity-native-bin": "^0.1.4-alpha.0",
+    "filenamify": "^4.1.0",
     "semver": "^6.1.1",
     "yeoman-generator": "^4.0.1"
   },

--- a/packages/generator-clarity-dev/package.json
+++ b/packages/generator-clarity-dev/package.json
@@ -34,12 +34,14 @@
   "dependencies": {
     "@blockstack/clarity": "^0.1.5-alpha.0",
     "@blockstack/clarity-native-bin": "^0.1.4-alpha.0",
+    "semver": "^6.1.1",
     "yeoman-generator": "^4.0.1"
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",
     "@types/mocha": "^5.2.7",
     "@types/node": "^10",
+    "@types/semver": "^6.0.1",
     "@types/yeoman-assert": "^3.1.1",
     "@types/yeoman-environment": "^2.3.1",
     "@types/yeoman-generator": "^3.1.3",

--- a/packages/generator-clarity-dev/package.json
+++ b/packages/generator-clarity-dev/package.json
@@ -34,7 +34,6 @@
   "dependencies": {
     "@blockstack/clarity": "^0.1.5-alpha.0",
     "@blockstack/clarity-native-bin": "^0.1.4-alpha.0",
-    "filenamify": "^4.1.0",
     "github-username": "^5.0.1",
     "semver": "^6.1.1",
     "yeoman-generator": "^4.0.1"

--- a/packages/generator-clarity-dev/package.json
+++ b/packages/generator-clarity-dev/package.json
@@ -35,6 +35,7 @@
     "@blockstack/clarity": "^0.1.5-alpha.0",
     "@blockstack/clarity-native-bin": "^0.1.4-alpha.0",
     "filenamify": "^4.1.0",
+    "github-username": "^5.0.1",
     "semver": "^6.1.1",
     "yeoman-generator": "^4.0.1"
   },

--- a/packages/generator-clarity-dev/package.json
+++ b/packages/generator-clarity-dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-clarity-dev",
-  "version": "0.1.5-alpha.0",
+  "version": "0.1.6-alpha.0",
   "description": "Yeoman generator to setup a Clarity development environment",
   "author": "Blockstack <engineering@blockstack.com> (https://blockstack.com/)",
   "license": "MIT",
@@ -32,8 +32,8 @@
     "test": "npm run build && nyc mocha"
   },
   "dependencies": {
-    "@blockstack/clarity": "^0.1.5-alpha.0",
-    "@blockstack/clarity-native-bin": "^0.1.4-alpha.0",
+    "@blockstack/clarity": "^0.1.6-alpha.0",
+    "@blockstack/clarity-native-bin": "^0.1.6-alpha.0",
     "github-username": "^5.0.1",
     "semver": "^6.1.1",
     "yeoman-generator": "^4.0.1"

--- a/packages/generator-clarity-dev/package.json
+++ b/packages/generator-clarity-dev/package.json
@@ -10,8 +10,8 @@
   "publishConfig": {
     "access": "public"
   },
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "main": "generators/index.js",
+  "types": "generators/index.d.ts",
   "engines": {
     "node": ">=10"
   },

--- a/packages/generator-clarity-dev/src/app/index.ts
+++ b/packages/generator-clarity-dev/src/app/index.ts
@@ -56,7 +56,7 @@ function inheritDevDependencies(src: PackageJson, target: PackageJson, names: st
 
 const PROJECT_DIR = "project_name";
 
-module.exports = class extends Generator {
+class ClarityDevGenerator extends Generator {
   packageJsonTemplateData: any;
 
   constructor(args: string | string[], options: any) {
@@ -184,4 +184,6 @@ module.exports = class extends Generator {
     const outputPath = this.destinationRoot();
     this.log(`Project created at ${outputPath}`);
   }
-};
+}
+
+export default ClarityDevGenerator;

--- a/packages/generator-clarity-dev/src/app/index.ts
+++ b/packages/generator-clarity-dev/src/app/index.ts
@@ -1,8 +1,20 @@
+import semver = require("semver");
 import Generator = require("yeoman-generator");
 
-type Mutable<T> = { -readonly [P in keyof T]: Mutable<T[P]> };
+const generatorPackage: PackageJson = require("../../package.json");
 
+type Mutable<T> = { -readonly [P in keyof T]: Mutable<T[P]> };
 type PackageJson = Mutable<Required<import("package-json").FullVersion>>;
+
+const version = generatorPackage.engines.node;
+if (!semver.satisfies(process.version, version)) {
+  console.error(
+    `Node.js version ${version} is required. Installed version ${
+      process.version
+    } is not compatible.`
+  );
+  process.exit(1);
+}
 
 function inheritDependencies(src: PackageJson, target: PackageJson, names: string[]) {
   for (const name of names) {
@@ -63,7 +75,6 @@ module.exports = class extends Generator {
     this.fs.copy(this.templatePath("_.gitignore"), this.destinationPath(".gitignore"));
     this.fs.copy(this.templatePath("_package.json"), this.destinationPath("package.json"));
 
-    const generatorGeneratorPkg: PackageJson = require("../../package.json");
     const pkgJson: PackageJson = {
       dependencies: {},
       devDependencies: {},
@@ -72,11 +83,11 @@ module.exports = class extends Generator {
       }
     } as any;
 
-    inheritDependencies(generatorGeneratorPkg, pkgJson, [
+    inheritDependencies(generatorPackage, pkgJson, [
       "@blockstack/clarity",
       "@blockstack/clarity-native-bin"
     ]);
-    inheritDevDependencies(generatorGeneratorPkg, pkgJson, [
+    inheritDevDependencies(generatorPackage, pkgJson, [
       "typescript",
       "ts-node",
       "chai",

--- a/packages/generator-clarity-dev/src/app/index.ts
+++ b/packages/generator-clarity-dev/src/app/index.ts
@@ -1,4 +1,3 @@
-import filenamify = require("filenamify");
 import fs = require("fs");
 import githubUsername = require("github-username");
 import path = require("path");
@@ -74,10 +73,8 @@ class ClarityDevGenerator extends Generator {
 
     let destRoot: string | undefined;
     if (projDirArg) {
-      // Normalize file path.
-      let pathParts = projDirArg.split(/\/|\\/g);
-      pathParts = pathParts.map((part: string) => filenamify(part, { replacement: "-" }));
-      projDirArg = path.join(...pathParts);
+      const normalizedPath = projDirArg.replace(/\/|\\/g, path.sep);
+      projDirArg = normalizedPath;
       destRoot = this.destinationRoot(projDirArg);
     } else {
       destRoot = this.destinationRoot();

--- a/packages/generator-clarity-dev/src/index.ts
+++ b/packages/generator-clarity-dev/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./modularGen";

--- a/packages/generator-clarity-dev/src/modularGen.ts
+++ b/packages/generator-clarity-dev/src/modularGen.ts
@@ -1,0 +1,27 @@
+import path = require("path");
+import YeoEnv = require("yeoman-environment");
+import Generator = require("yeoman-generator");
+
+export function createAppGen({
+  args,
+  options
+}: {
+  args?: string | string[];
+  options?: {
+    [key: string]: any;
+  };
+} = {}) {
+  const appPath = path.join(__dirname, "../generators/app");
+  const generatorName = "clarity:dev";
+  const env = YeoEnv.createEnv();
+  env.register(appPath, generatorName);
+
+  const genOpts = { arguments: args, options: options };
+  const instance = (env.create("clarity:dev", genOpts) as unknown) as Generator;
+
+  const runFn = () => {
+    return Promise.resolve(instance.run()) as Promise<unknown>;
+  };
+
+  return { run: runFn, env: env, generator: instance };
+}

--- a/packages/generator-clarity-dev/test/generateDirArg.ts
+++ b/packages/generator-clarity-dev/test/generateDirArg.ts
@@ -1,5 +1,4 @@
-import fs from "fs";
-import path from "path";
+import path = require("path");
 import assert = require("yeoman-assert");
 import yo_env = require("yeoman-environment");
 import Generator = require("yeoman-generator");
@@ -25,7 +24,7 @@ describe("generator tests", () => {
 
   it("generate a project", async () => {
     const appPath = path.join(__dirname, "../generators/app");
-    const projectName = path.join("example-proj");
+    const projectName = "example-proj";
     generator = helpers.createGenerator("clarity-dev", [appPath], [projectName], {
       skipInstall: false
     });

--- a/packages/generator-clarity-dev/test/generateDirArg.ts
+++ b/packages/generator-clarity-dev/test/generateDirArg.ts
@@ -1,0 +1,67 @@
+import fs from "fs";
+import path from "path";
+import assert = require("yeoman-assert");
+import yo_env = require("yeoman-environment");
+import Generator = require("yeoman-generator");
+import helpers = require("yeoman-test");
+import utils = require("./util");
+
+describe("generator tests", () => {
+  let testingDir: string;
+  let generator: Generator;
+
+  before(async () => {
+    testingDir = path.join(__dirname, "../.yo-test");
+    await new Promise((resolve, reject) => {
+      helpers.testDirectory(testingDir, err => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+  });
+
+  it("generate a project", async () => {
+    const appPath = path.join(__dirname, "../generators/app");
+    const projectName = path.join("example-proj");
+    generator = helpers.createGenerator("clarity-dev", [appPath], [projectName], {
+      skipInstall: false
+    });
+
+    // Setup local dependencies.
+    const moduleClarityCore = path.join(__dirname, "../../clarity");
+    const moduleClarityNativeBin = path.join(__dirname, "../../clarity-native-bin");
+    generator.npmInstall([moduleClarityCore, moduleClarityNativeBin]);
+
+    // Run yo-generator to output project.
+    await Promise.resolve(generator.run());
+
+    // Validate output directory.
+    const outputDir = generator.destinationRoot();
+    assert.strictEqual(path.basename(outputDir), path.basename(projectName));
+  });
+
+  it("generated files", () => {
+    assert.file(utils.EXPECTED_OUTPUT_FILES);
+  });
+
+  it("run npm test", () => {
+    // Ensure `npm test` succeeds in generated project.
+    generator.spawnCommandSync("npm", ["test"]);
+  });
+
+  after(async () => {
+    // Clean temp output dir.
+    await new Promise((resolve, reject) => {
+      helpers.testDirectory(testingDir, err => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+  });
+});

--- a/packages/generator-clarity-dev/test/generateDirExisting.ts
+++ b/packages/generator-clarity-dev/test/generateDirExisting.ts
@@ -1,5 +1,4 @@
-import fs from "fs";
-import path from "path";
+import path = require("path");
 import assert = require("yeoman-assert");
 import yo_env = require("yeoman-environment");
 import Generator = require("yeoman-generator");

--- a/packages/generator-clarity-dev/test/generateDirExisting.ts
+++ b/packages/generator-clarity-dev/test/generateDirExisting.ts
@@ -1,0 +1,66 @@
+import fs from "fs";
+import path from "path";
+import assert = require("yeoman-assert");
+import yo_env = require("yeoman-environment");
+import Generator = require("yeoman-generator");
+import helpers = require("yeoman-test");
+import utils = require("./util");
+
+describe("generator tests [existing proj dir]", () => {
+  let testingDir: string;
+  let generator: Generator;
+
+  before(async () => {
+    testingDir = path.join(__dirname, "../.yo-test/example-proj");
+    await new Promise((resolve, reject) => {
+      helpers.testDirectory(testingDir, err => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+  });
+
+  it("generate a project", async () => {
+    const appPath = path.join(__dirname, "../generators/app");
+    generator = helpers.createGenerator("clarity-dev", [appPath], [], {
+      skipInstall: false
+    });
+
+    // Setup local dependencies.
+    const moduleClarityCore = path.join(__dirname, "../../clarity");
+    const moduleClarityNativeBin = path.join(__dirname, "../../clarity-native-bin");
+    generator.npmInstall([moduleClarityCore, moduleClarityNativeBin]);
+
+    // Run yo-generator to output project.
+    await Promise.resolve(generator.run());
+
+    // Validate output directory.
+    const outputDir = generator.destinationRoot();
+    assert.strictEqual(path.basename(outputDir), path.basename("example-proj"));
+  });
+
+  it("generated files", () => {
+    assert.file(utils.EXPECTED_OUTPUT_FILES);
+  });
+
+  it("run npm test", () => {
+    // Ensure `npm test` succeeds in generated project.
+    generator.spawnCommandSync("npm", ["test"]);
+  });
+
+  after(async () => {
+    // Clean temp output dir.
+    await new Promise((resolve, reject) => {
+      helpers.testDirectory(testingDir, err => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+  });
+});

--- a/packages/generator-clarity-dev/test/generateDirPrompt.ts
+++ b/packages/generator-clarity-dev/test/generateDirPrompt.ts
@@ -4,8 +4,9 @@ import assert = require("yeoman-assert");
 import yo_env = require("yeoman-environment");
 import Generator = require("yeoman-generator");
 import helpers = require("yeoman-test");
+import utils = require("./util");
 
-describe("generator tests", () => {
+describe("generator tests [in non-empty dir]", () => {
   let testingDir: string;
   let generator: Generator;
 
@@ -22,12 +23,16 @@ describe("generator tests", () => {
     });
   });
 
+  it("add existing files to output dir", async () => {
+    fs.writeFileSync(path.join(testingDir, "something.txt"), "x");
+  });
+
   it("generate a project", async () => {
     const appPath = path.join(__dirname, "../generators/app");
-    generator = helpers.createGenerator("clarity-dev", [appPath], ["example-proj"], {
+    generator = helpers.createGenerator("clarity-dev", [appPath], [], {
       skipInstall: false
     });
-
+    helpers.mockPrompt(generator, { project_name: "tmp-example" });
     // Setup local dependencies.
     const moduleClarityCore = path.join(__dirname, "../../clarity");
     const moduleClarityNativeBin = path.join(__dirname, "../../clarity-native-bin");
@@ -36,21 +41,13 @@ describe("generator tests", () => {
     // Run yo-generator to output project.
     await Promise.resolve(generator.run());
 
+    // Validate output directory.
     const outputDir = generator.destinationRoot();
-    assert.strictEqual(path.basename(outputDir), "example-proj");
+    assert.strictEqual(path.basename(outputDir), "tmp-example");
   });
 
   it("generated files", () => {
-    assert.file([
-      ".gitignore",
-      "package.json",
-      "tsconfig.json",
-      "contracts/sample/hello-world.clar",
-      "test/hello-world.ts",
-      "test/mocha.opts",
-      ".vscode/extensions.json",
-      ".vscode/launch.json"
-    ]);
+    assert.file(utils.EXPECTED_OUTPUT_FILES);
   });
 
   it("run npm test", () => {

--- a/packages/generator-clarity-dev/test/index.ts
+++ b/packages/generator-clarity-dev/test/index.ts
@@ -24,7 +24,7 @@ describe("generator tests", () => {
 
   it("generate a project", async () => {
     const appPath = path.join(__dirname, "../generators/app");
-    generator = helpers.createGenerator("clarity-dev", [appPath], undefined, {
+    generator = helpers.createGenerator("clarity-dev", [appPath], ["example-proj"], {
       skipInstall: false
     });
 
@@ -35,6 +35,9 @@ describe("generator tests", () => {
 
     // Run yo-generator to output project.
     await Promise.resolve(generator.run());
+
+    const outputDir = generator.destinationRoot();
+    assert.strictEqual(path.basename(outputDir), "example-proj");
   });
 
   it("generated files", () => {

--- a/packages/generator-clarity-dev/test/util.ts
+++ b/packages/generator-clarity-dev/test/util.ts
@@ -1,0 +1,10 @@
+export const EXPECTED_OUTPUT_FILES = [
+  ".gitignore",
+  "package.json",
+  "tsconfig.json",
+  "contracts/sample/hello-world.clar",
+  "test/hello-world.ts",
+  "test/mocha.opts",
+  ".vscode/extensions.json",
+  ".vscode/launch.json"
+];


### PR DESCRIPTION
Reference issue: https://github.com/blockstack/clarity-js-sdk/issues/19

- [x] Runtime checks for min Node.js version for node-runtime-only (ones that will never be used in browser env) packages: generator-clarity-dev, clarity-native-bin.
   > Improve obscure errors like `TypeError [ERR_INVALID_ARG_TYPE]: The "original" argument must be of type function` with something useful like `Node.js version >=10 is required. Installed version v8.16.0 is not compatible`
- [x] Clean up hello-world contracts.
- [x] Use yeoman features like git email, git name, github username, etc for defaults in generated package.json (see https://yeoman.github.io/generator/actions_user.html)
- [x] Use [yeoman-enviroment](https://yeoman.io/authoring/integrating-yeoman.html) in `clarity-cli` package.
  > Allow for 
  > ```bash
  > npm install -g @blockstack/clarity-cli && clarity new hello-world
  > # or shorthand:
  > npx @blockstack/clarity-cli new hello-world
  > ```
  > Without `yo` and `create-yo` reducing dev-ux.