### PR TITLE
Hotfix - yo package fix

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.1.6-alpha.0"
+  "version": "0.1.7-alpha.0"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.1.7-alpha.0"
+  "version": "0.1.8-alpha.0"
 }

--- a/packages/clarity-cli/README.md
+++ b/packages/clarity-cli/README.md
@@ -10,7 +10,7 @@ $ npm install -g @blockstack/clarity-cli
 $ clarity COMMAND
 running command...
 $ clarity (-v|--version|version)
-@blockstack/clarity-cli/0.1.6-alpha.0 darwin-x64 node-v10.15.3
+@blockstack/clarity-cli/0.1.7-alpha.0 darwin-x64 node-v10.15.3
 $ clarity --help [COMMAND]
 USAGE
   $ clarity COMMAND

--- a/packages/clarity-cli/package-lock.json
+++ b/packages/clarity-cli/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockstack/clarity-cli",
-	"version": "0.1.5-alpha.0",
+	"version": "0.1.6-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/clarity-cli/package-lock.json
+++ b/packages/clarity-cli/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockstack/clarity-cli",
-	"version": "0.1.6-alpha.0",
+	"version": "0.1.7-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/clarity-cli/package.json
+++ b/packages/clarity-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockstack/clarity-cli",
-  "version": "0.1.7-alpha.0",
+  "version": "0.1.8-alpha.0",
   "description": "The Clarity CLI is used to manage Clarity smart contracts from the command line.",
   "author": "Blockstack <engineering@blockstack.com> (https://blockstack.com/)",
   "license": "MIT",
@@ -45,13 +45,13 @@
     "test": "npm run build && nyc mocha"
   },
   "dependencies": {
-    "@blockstack/clarity": "^0.1.7-alpha.0",
-    "@blockstack/clarity-native-bin": "^0.1.7-alpha.0",
+    "@blockstack/clarity": "^0.1.8-alpha.0",
+    "@blockstack/clarity-native-bin": "^0.1.8-alpha.0",
     "@oclif/command": "^1.5.13",
     "@oclif/config": "^1.13.0",
     "@oclif/plugin-help": "^2.1.6",
     "fs-extra": "^8.0.1",
-    "generator-clarity-dev": "^0.1.7-alpha.0",
+    "generator-clarity-dev": "^0.1.8-alpha.0",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/packages/clarity-cli/package.json
+++ b/packages/clarity-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockstack/clarity-cli",
-  "version": "0.1.6-alpha.0",
+  "version": "0.1.7-alpha.0",
   "description": "The Clarity CLI is used to manage Clarity smart contracts from the command line.",
   "author": "Blockstack <engineering@blockstack.com> (https://blockstack.com/)",
   "license": "MIT",
@@ -45,13 +45,13 @@
     "test": "npm run build && nyc mocha"
   },
   "dependencies": {
-    "@blockstack/clarity": "^0.1.6-alpha.0",
-    "@blockstack/clarity-native-bin": "^0.1.6-alpha.0",
+    "@blockstack/clarity": "^0.1.7-alpha.0",
+    "@blockstack/clarity-native-bin": "^0.1.7-alpha.0",
     "@oclif/command": "^1.5.13",
     "@oclif/config": "^1.13.0",
     "@oclif/plugin-help": "^2.1.6",
     "fs-extra": "^8.0.1",
-    "generator-clarity-dev": "^0.1.6-alpha.0",
+    "generator-clarity-dev": "^0.1.7-alpha.0",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/packages/clarity-native-bin/package-lock.json
+++ b/packages/clarity-native-bin/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockstack/clarity-native-bin",
-	"version": "0.1.6-alpha.0",
+	"version": "0.1.7-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/clarity-native-bin/package-lock.json
+++ b/packages/clarity-native-bin/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockstack/clarity-native-bin",
-	"version": "0.1.4-alpha.0",
+	"version": "0.1.6-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/clarity-native-bin/package.json
+++ b/packages/clarity-native-bin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockstack/clarity-native-bin",
-  "version": "0.1.6-alpha.0",
+  "version": "0.1.7-alpha.0",
   "description": "Library for providing the native Clarity CLI binary",
   "author": "Blockstack <engineering@blockstack.com> (https://blockstack.com/)",
   "license": "MIT",

--- a/packages/clarity-native-bin/package.json
+++ b/packages/clarity-native-bin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockstack/clarity-native-bin",
-  "version": "0.1.7-alpha.0",
+  "version": "0.1.8-alpha.0",
   "description": "Library for providing the native Clarity CLI binary",
   "author": "Blockstack <engineering@blockstack.com> (https://blockstack.com/)",
   "license": "MIT",

--- a/packages/clarity-tslint/package-lock.json
+++ b/packages/clarity-tslint/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockstack/clarity-tslint",
-	"version": "0.1.4-alpha.0",
+	"version": "0.1.6-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/clarity-tslint/package-lock.json
+++ b/packages/clarity-tslint/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockstack/clarity-tslint",
-	"version": "0.1.6-alpha.0",
+	"version": "0.1.7-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/clarity-tslint/package.json
+++ b/packages/clarity-tslint/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@blockstack/clarity-tslint",
   "description": "tslint rules for blockstack",
-  "version": "0.1.7-alpha.0",
+  "version": "0.1.8-alpha.0",
   "author": "Blockstack <engineering@blockstack.com> (https://blockstack.com/)",
   "devDependencies": {
     "prettier": "1.17.1",

--- a/packages/clarity-tslint/package.json
+++ b/packages/clarity-tslint/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@blockstack/clarity-tslint",
   "description": "tslint rules for blockstack",
-  "version": "0.1.6-alpha.0",
+  "version": "0.1.7-alpha.0",
   "author": "Blockstack <engineering@blockstack.com> (https://blockstack.com/)",
   "devDependencies": {
     "prettier": "1.17.1",

--- a/packages/clarity-tutorials/package-lock.json
+++ b/packages/clarity-tutorials/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockstack/clarity-tutorials",
-	"version": "0.1.5-alpha.0",
+	"version": "0.1.6-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/clarity-tutorials/package-lock.json
+++ b/packages/clarity-tutorials/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockstack/clarity-tutorials",
-	"version": "0.1.6-alpha.0",
+	"version": "0.1.7-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/clarity-tutorials/package.json
+++ b/packages/clarity-tutorials/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockstack/clarity-tutorials",
-  "version": "0.1.7-alpha.0",
+  "version": "0.1.8-alpha.0",
   "description": "Getting started with Clarity",
   "author": "Blockstack <engineering@blockstack.com> (https://blockstack.com/)",
   "license": "MIT",
@@ -28,8 +28,8 @@
     "/contracts"
   ],
   "dependencies": {
-    "@blockstack/clarity": "^0.1.7-alpha.0",
-    "@blockstack/clarity-native-bin": "^0.1.7-alpha.0"
+    "@blockstack/clarity": "^0.1.8-alpha.0",
+    "@blockstack/clarity-native-bin": "^0.1.8-alpha.0"
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",

--- a/packages/clarity-tutorials/package.json
+++ b/packages/clarity-tutorials/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockstack/clarity-tutorials",
-  "version": "0.1.6-alpha.0",
+  "version": "0.1.7-alpha.0",
   "description": "Getting started with Clarity",
   "author": "Blockstack <engineering@blockstack.com> (https://blockstack.com/)",
   "license": "MIT",
@@ -28,8 +28,8 @@
     "/contracts"
   ],
   "dependencies": {
-    "@blockstack/clarity": "^0.1.6-alpha.0",
-    "@blockstack/clarity-native-bin": "^0.1.6-alpha.0"
+    "@blockstack/clarity": "^0.1.7-alpha.0",
+    "@blockstack/clarity-native-bin": "^0.1.7-alpha.0"
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",

--- a/packages/clarity/package-lock.json
+++ b/packages/clarity/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockstack/clarity",
-	"version": "0.1.5-alpha.0",
+	"version": "0.1.6-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/clarity/package-lock.json
+++ b/packages/clarity/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockstack/clarity",
-	"version": "0.1.6-alpha.0",
+	"version": "0.1.7-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/clarity/package.json
+++ b/packages/clarity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockstack/clarity",
-  "version": "0.1.6-alpha.0",
+  "version": "0.1.7-alpha.0",
   "description": "Clarity JS SDK - Core library",
   "author": "Blockstack <engineering@blockstack.com> (https://blockstack.com/)",
   "license": "MIT",
@@ -31,7 +31,7 @@
     "@blockstack/clarity-native-bin": "^0.1.4-alpha.0"
   },
   "devDependencies": {
-    "@blockstack/clarity-native-bin": "^0.1.6-alpha.0",
+    "@blockstack/clarity-native-bin": "^0.1.7-alpha.0",
     "@types/chai": "^4.1.7",
     "@types/mocha": "^5.2.7",
     "@types/node": "^10",

--- a/packages/clarity/package.json
+++ b/packages/clarity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockstack/clarity",
-  "version": "0.1.7-alpha.0",
+  "version": "0.1.8-alpha.0",
   "description": "Clarity JS SDK - Core library",
   "author": "Blockstack <engineering@blockstack.com> (https://blockstack.com/)",
   "license": "MIT",
@@ -31,7 +31,7 @@
     "@blockstack/clarity-native-bin": "^0.1.4-alpha.0"
   },
   "devDependencies": {
-    "@blockstack/clarity-native-bin": "^0.1.7-alpha.0",
+    "@blockstack/clarity-native-bin": "^0.1.8-alpha.0",
     "@types/chai": "^4.1.7",
     "@types/mocha": "^5.2.7",
     "@types/node": "^10",

--- a/packages/generator-clarity-dev/package-lock.json
+++ b/packages/generator-clarity-dev/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-clarity-dev",
-  "version": "0.1.5-alpha.0",
+  "version": "0.1.6-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/generator-clarity-dev/package-lock.json
+++ b/packages/generator-clarity-dev/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-clarity-dev",
-  "version": "0.1.6-alpha.0",
+  "version": "0.1.7-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/generator-clarity-dev/package.json
+++ b/packages/generator-clarity-dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-clarity-dev",
-  "version": "0.1.6-alpha.0",
+  "version": "0.1.7-alpha.0",
   "description": "Yeoman generator to setup a Clarity development environment",
   "author": "Blockstack <engineering@blockstack.com> (https://blockstack.com/)",
   "license": "MIT",
@@ -32,8 +32,8 @@
     "test": "npm run build && nyc mocha"
   },
   "dependencies": {
-    "@blockstack/clarity": "^0.1.6-alpha.0",
-    "@blockstack/clarity-native-bin": "^0.1.6-alpha.0",
+    "@blockstack/clarity": "^0.1.7-alpha.0",
+    "@blockstack/clarity-native-bin": "^0.1.7-alpha.0",
     "github-username": "^5.0.1",
     "semver": "^6.1.1",
     "yeoman-generator": "^4.0.1"

--- a/packages/generator-clarity-dev/package.json
+++ b/packages/generator-clarity-dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-clarity-dev",
-  "version": "0.1.7-alpha.0",
+  "version": "0.1.8-alpha.0",
   "description": "Yeoman generator to setup a Clarity development environment",
   "author": "Blockstack <engineering@blockstack.com> (https://blockstack.com/)",
   "license": "MIT",
@@ -31,8 +31,8 @@
     "test": "npm run build && nyc mocha"
   },
   "dependencies": {
-    "@blockstack/clarity": "^0.1.7-alpha.0",
-    "@blockstack/clarity-native-bin": "^0.1.7-alpha.0",
+    "@blockstack/clarity": "^0.1.8-alpha.0",
+    "@blockstack/clarity-native-bin": "^0.1.8-alpha.0",
     "github-username": "^5.0.1",
     "semver": "^6.1.1",
     "yeoman-generator": "^4.0.1"

--- a/packages/generator-clarity-dev/package.json
+++ b/packages/generator-clarity-dev/package.json
@@ -10,8 +10,8 @@
   "publishConfig": {
     "access": "public"
   },
-  "main": "generators/index.js",
-  "types": "generators/index.d.ts",
+  "main": "generators/modularGen.js",
+  "types": "generators/modularGen.d.ts",
   "engines": {
     "node": ">=10"
   },
@@ -19,7 +19,6 @@
     "yeoman-generator"
   ],
   "files": [
-    "/lib",
     "/generators"
   ],
   "scripts": {

--- a/packages/generator-clarity-dev/src/app/index.ts
+++ b/packages/generator-clarity-dev/src/app/index.ts
@@ -55,7 +55,7 @@ function inheritDevDependencies(src: PackageJson, target: PackageJson, names: st
 
 const PROJECT_DIR = "project_name";
 
-class ClarityDevGenerator extends Generator {
+module.exports = class extends Generator {
   packageJsonTemplateData: any;
 
   constructor(args: string | string[], options: any) {
@@ -181,6 +181,4 @@ class ClarityDevGenerator extends Generator {
     const outputPath = this.destinationRoot();
     this.log(`Project created at ${outputPath}`);
   }
-}
-
-export default ClarityDevGenerator;
+};

--- a/packages/generator-clarity-dev/src/index.ts
+++ b/packages/generator-clarity-dev/src/index.ts
@@ -1,1 +1,0 @@
-export * from "./modularGen";

--- a/packages/generator-clarity-dev/src/modularGen.ts
+++ b/packages/generator-clarity-dev/src/modularGen.ts
@@ -17,7 +17,7 @@ export function createAppGen({
   env.register(appPath, generatorName);
 
   const genOpts = { arguments: args, options: options };
-  const instance = (env.create("clarity:dev", genOpts) as unknown) as Generator;
+  const instance = (env.create(generatorName, genOpts) as unknown) as Generator;
 
   const runFn = () => {
     return Promise.resolve(instance.run()) as Promise<unknown>;

--- a/packages/generator-clarity-dev/test/generateDirArg.ts
+++ b/packages/generator-clarity-dev/test/generateDirArg.ts
@@ -25,7 +25,7 @@ describe("generator tests", () => {
   it("generate a project", async () => {
     const appPath = path.join(__dirname, "../generators/app");
     const projectName = "example-proj";
-    generator = helpers.createGenerator("clarity-dev", [appPath], [projectName], {
+    generator = helpers.createGenerator(appPath, [], [projectName], {
       skipInstall: false
     });
 

--- a/packages/generator-clarity-dev/test/generateDirExisting.ts
+++ b/packages/generator-clarity-dev/test/generateDirExisting.ts
@@ -24,7 +24,7 @@ describe("generator tests [existing proj dir]", () => {
 
   it("generate a project", async () => {
     const appPath = path.join(__dirname, "../generators/app");
-    generator = helpers.createGenerator("clarity-dev", [appPath], [], {
+    generator = helpers.createGenerator(appPath, [], [], {
       skipInstall: false
     });
 

--- a/packages/generator-clarity-dev/test/generateDirPrompt.ts
+++ b/packages/generator-clarity-dev/test/generateDirPrompt.ts
@@ -29,7 +29,7 @@ describe("generator tests [in non-empty dir]", () => {
 
   it("generate a project", async () => {
     const appPath = path.join(__dirname, "../generators/app");
-    generator = helpers.createGenerator("clarity-dev", [appPath], [], {
+    generator = helpers.createGenerator(appPath, [], [], {
       skipInstall: false
     });
     helpers.mockPrompt(generator, { project_name: "tmp-example" });


### PR DESCRIPTION
Including a `index.js` in the `generator-clarity-dev` silently breaks regular usage of `yo`.