### PR TITLE
Fix/clarity native bin scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1093,6 +1093,15 @@
         "url-template": "^2.0.8"
       }
     },
+    "@types/fs-extra": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.0.0.tgz",
+      "integrity": "sha512-bCtL5v9zdbQW86yexOlXWTEGvLNqWxMFyi7gQA7Gcthbezr2cPSOb8SkESVKA937QD5cIwOFLDFt0MQoXOEr9Q==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/node": {
       "version": "10.14.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.8.tgz",
@@ -2625,6 +2634,25 @@
       "requires": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
+      }
+    },
+    "fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
+          "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
+          "dev": true
+        }
       }
     },
     "fs-minipass": {

--- a/package.json
+++ b/package.json
@@ -24,9 +24,11 @@
     "codecov-upload": "codecov"
   },
   "devDependencies": {
+    "@types/fs-extra": "^8.0.0",
     "@types/node": "^10.14.8",
     "codecov": "^3.5.0",
     "cross-env": "^5.2.0",
+    "fs-extra": "^8.1.0",
     "lerna": "^3.14.1",
     "typescript": "^3.5.1"
   }

--- a/packages/clarity-native-bin/postInstallScript.js
+++ b/packages/clarity-native-bin/postInstallScript.js
@@ -54,5 +54,5 @@ function tsNodeInstall() {
   const directInstallTsFile = path.join(__dirname, "src", "directInstall.ts");
   const tsNodeExecArgs = [tsNodePkg, "--project", tsConfigBuildFile, directInstallTsFile];
   console.log(`Running: npx ${tsNodeExecArgs.join(" ")}`);
-  childProcess.execFileSync("npx", tsNodeExecArgs, { stdio: ['pipe', process.stdout, process.stderr] });
+  childProcess.execFileSync("npx", tsNodeExecArgs, { stdio: ['pipe', process.stdout, process.stderr], shell: process.platform=="win32" });
 }

--- a/packages/clarity-native-bin/src/cargoBuild.ts
+++ b/packages/clarity-native-bin/src/cargoBuild.ts
@@ -1,4 +1,4 @@
-import * as fs from "fs";
+import * as fs from "fs-extra";
 import * as path from "path";
 import { executeCommand } from "./execUtil";
 import { getExecutableFileName, makeUniqueTempDir } from "./fsUtil";
@@ -88,7 +88,7 @@ export async function cargoInstall(opts: {
   const tempBinFilePath = path.join(tempCompileBinDir, binFileName);
 
   opts.logger.log(`Moving ${tempBinFilePath} to ${opts.outputFilePath}`);
-  fs.renameSync(tempBinFilePath, opts.outputFilePath);
+  fs.moveSync(tempBinFilePath, opts.outputFilePath);
 
   return true;
 }

--- a/packages/clarity-native-bin/src/fetchDist.ts
+++ b/packages/clarity-native-bin/src/fetchDist.ts
@@ -1,4 +1,4 @@
-import * as fs from "fs";
+import * as fs from "fs-extra";
 import fetch from "node-fetch";
 import * as os from "os";
 import * as path from "path";
@@ -119,8 +119,8 @@ export async function fetchDistributable(opts: {
   const tempBinFilePath = path.join(tempExtractDir, binFileName);
 
   opts.logger.log(`Moving ${tempBinFilePath} to ${opts.outputFilePath}`);
-  fs.renameSync(tempBinFilePath, opts.outputFilePath);
-  fs.rmdirSync(tempExtractDir);
+  fs.moveSync(tempBinFilePath, opts.outputFilePath);
+  fs.removeSync(tempExtractDir);
 
   return true;
 }

--- a/packages/clarity-native-bin/src/fsUtil.ts
+++ b/packages/clarity-native-bin/src/fsUtil.ts
@@ -1,4 +1,4 @@
-import * as fs from "fs";
+import * as fs from "fs-extra";
 import * as os from "os";
 import * as path from "path";
 import { ILogger } from "./logger";

--- a/packages/clarity-native-bin/src/index.ts
+++ b/packages/clarity-native-bin/src/index.ts
@@ -1,4 +1,4 @@
-import * as fs from "fs";
+import * as fs from "fs-extra";
 import * as path from "path";
 import { cargoInstall } from "./cargoBuild";
 import { fetchDistributable, getDownloadUrl } from "./fetchDist";

--- a/packages/clarity-native-bin/test/installFromDist.ts
+++ b/packages/clarity-native-bin/test/installFromDist.ts
@@ -1,5 +1,5 @@
 import { assert } from "chai";
-import fs from "fs";
+import fs from "fs-extra";
 import path from "path";
 import { CORE_SDK_TAG, install } from "../src";
 import { makeUniqueTempDir } from "../src/fsUtil";
@@ -35,7 +35,7 @@ describe("install via dist", () => {
       fs.unlinkSync(filePath);
     }
     if (fs.existsSync(tempDir)) {
-      fs.rmdirSync(tempDir);
+      fs.removeSync(tempDir);
     }
   });
 });

--- a/packages/clarity-native-bin/test/installFromSource.ts
+++ b/packages/clarity-native-bin/test/installFromSource.ts
@@ -1,5 +1,5 @@
 import { assert } from "chai";
-import fs from "fs";
+import fs from "fs-extra";
 import path from "path";
 import { CORE_SDK_TAG, install } from "../src";
 import { makeUniqueTempDir } from "../src/fsUtil";
@@ -9,7 +9,7 @@ describe("install via build from source", () => {
   let tempDir: string;
   let filePath: string;
 
-  before(function() {
+  before(function () {
     if (process.env.SKIP_SLOW_TESTS) {
       this.skip();
       return;
@@ -39,7 +39,7 @@ describe("install via build from source", () => {
       fs.unlinkSync(filePath);
     }
     if (fs.existsSync(tempDir)) {
-      fs.rmdirSync(tempDir);
+      fs.removeSync(tempDir);
     }
   });
 });

--- a/packages/clarity/src/providers/clarityBin/index.ts
+++ b/packages/clarity/src/providers/clarityBin/index.ts
@@ -1,4 +1,4 @@
-import fs from "fs";
+import fs from "fs-extra";
 import { CheckResult, Receipt } from "../../core";
 import { Provider } from "../../core/provider";
 import { getContractFilePath } from "../../utils/contractSourceDir";
@@ -155,7 +155,7 @@ export class NativeClarityBinProvider implements Provider {
     if (result.exitCode !== 0) {
       throw new ExecutionError(
         `Execute expression on contract failed with bad exit code ${result.exitCode}: ${
-          result.stderr
+        result.stderr
         }`,
         result.exitCode,
         result.stdout,
@@ -221,7 +221,7 @@ export class NativeClarityBinProvider implements Provider {
     if (result.exitCode !== 0) {
       throw new ExecutionError(
         `Eval expression on contract failed with bad exit code ${result.exitCode}: ${
-          result.stderr
+        result.stderr
         }`,
         result.exitCode,
         result.stdout,

--- a/packages/clarity/src/utils/fsUtil.ts
+++ b/packages/clarity/src/utils/fsUtil.ts
@@ -1,4 +1,4 @@
-import * as fs from "fs";
+import * as fs from "fs-extra";
 import * as os from "os";
 import * as path from "path";
 

--- a/packages/clarity/test/contractInterfaceTests.ts
+++ b/packages/clarity/test/contractInterfaceTests.ts
@@ -1,5 +1,5 @@
 import { assert } from "chai";
-import * as fs from "fs";
+import * as fs from "fs-extra";
 import * as path from "path";
 import {
   ContractInterface,


### PR DESCRIPTION
fixes #34 #35 

1. added fs-extra's moveSync and removeSync to avoid error `EXDEV: cross-device link not permitted, rename`

2. added shell param to execFileSync in postInstallScript to execute npx in windows env properly.