### PR TITLE
Detect 64bit system architecture with 32bit version of Node.js

### DIFF
--- a/packages/clarity-native-bin/src/detectArch.ts
+++ b/packages/clarity-native-bin/src/detectArch.ts
@@ -1,0 +1,68 @@
+// Gratefully borrowed from https://github.com/feross/arch/blob/master/index.js
+/*
+ > In Node.js, the os.arch() method (and process.arch property) returns a string
+ > identifying the operating system CPU architecture for which the Node.js binary
+ > was compiled. This is not the same as the operating system CPU architecture.
+ > For example, you can run Node.js 32-bit on a 64-bit OS. In that situation,
+ > os.arch() will return a misleading 'x86' (32-bit) value, instead of 'x64' (64-bit).
+ */
+
+import cp from "child_process";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+export function detectArch(): string {
+  try {
+    /**
+     * The running binary is 64-bit, so the OS is clearly 64-bit.
+     */
+    if (process.arch === "x64") {
+      return "x64";
+    }
+
+    /**
+     * On Windows, the most reliable way to detect a 64-bit OS from within a 32-bit
+     * app is based on the presence of a WOW64 file: %SystemRoot%\SysNative.
+     * See: https://twitter.com/feross/status/776949077208510464
+     */
+    if (process.platform === "win32" && os.arch() === "ia32") {
+      let useEnv = false;
+      try {
+        useEnv = !!(process.env.SYSTEMROOT && fs.statSync(process.env.SYSTEMROOT));
+      } catch (err) {
+        // ignore
+      }
+
+      const sysRoot = useEnv ? process.env.SYSTEMROOT! : "C:\\Windows";
+
+      // If %SystemRoot%\SysNative exists, we are in a WOW64 FS Redirected application.
+      let isWOW64 = false;
+      try {
+        isWOW64 = !!fs.statSync(path.join(sysRoot, "sysnative"));
+      } catch (err) {
+        // ignore
+      }
+      if (isWOW64) {
+        return "x64";
+      }
+    }
+
+    /**
+     * On Linux, use the `getconf` command to get the architecture.
+     */
+    if (process.platform === "linux" && os.arch() === "ia32") {
+      const output = cp.execSync("getconf LONG_BIT", { encoding: "utf8" });
+      if (output === "64\n") {
+        return "x64";
+      }
+    }
+  } catch (error) {
+    console.error(`Unexpected error trying to detect system architecture: ${error}`);
+  }
+
+  /**
+   * If none of the above, fallback to os.arch()
+   */
+  return os.arch();
+}

--- a/packages/clarity-native-bin/src/detectArch.ts
+++ b/packages/clarity-native-bin/src/detectArch.ts
@@ -1,4 +1,7 @@
 // Gratefully borrowed from https://github.com/feross/arch/blob/master/index.js
+// Note: Modified to only return `x64` when detecting a 32-bit Node.js on 64-bit
+// platform, otherwise returns `os.arch()`.
+
 /*
  > In Node.js, the os.arch() method (and process.arch property) returns a string
  > identifying the operating system CPU architecture for which the Node.js binary
@@ -11,8 +14,9 @@ import cp from "child_process";
 import fs from "fs";
 import os from "os";
 import path from "path";
+import { ConsoleLogger, ILogger } from "./logger";
 
-export function detectArch(): string {
+export function detectArch(logger: ILogger = ConsoleLogger): string {
   try {
     /**
      * The running binary is 64-bit, so the OS is clearly 64-bit.
@@ -58,7 +62,7 @@ export function detectArch(): string {
       }
     }
   } catch (error) {
-    console.error(`Unexpected error trying to detect system architecture: ${error}`);
+    logger.error(`Unexpected error trying to detect system architecture: ${error}`);
   }
 
   /**

--- a/packages/clarity-native-bin/src/fetchDist.ts
+++ b/packages/clarity-native-bin/src/fetchDist.ts
@@ -3,6 +3,7 @@ import fetch from "node-fetch";
 import * as os from "os";
 import * as path from "path";
 import * as tar from "tar";
+import { detectArch } from "./detectArch";
 import { detectLibc } from "./detectLibc";
 import { getExecutableFileName, makeUniqueTempDir } from "./fsUtil";
 import { ILogger } from "./logger";
@@ -32,13 +33,14 @@ export function isDistAvailable(
   logger?: ILogger
 ): { platform: SupportedDistPlatform; arch: SupportedDistArch } | false {
   let arch: SupportedDistArch;
-  switch (os.arch()) {
+  const detectedArch = detectArch();
+  switch (detectedArch) {
     case "x64":
       arch = SupportedDistArch.x64;
       break;
     default:
       if (logger) {
-        logger.error(`System arch "${os.arch()}" not supported. Must build from source.`);
+        logger.error(`System arch "${detectedArch}" not supported. Must build from source.`);
       }
       return false;
   }

--- a/packages/clarity-native-bin/src/fetchDist.ts
+++ b/packages/clarity-native-bin/src/fetchDist.ts
@@ -33,7 +33,7 @@ export function isDistAvailable(
   logger?: ILogger
 ): { platform: SupportedDistPlatform; arch: SupportedDistArch } | false {
   let arch: SupportedDistArch;
-  const detectedArch = detectArch();
+  const detectedArch = detectArch(logger);
   switch (detectedArch) {
     case "x64":
       arch = SupportedDistArch.x64;


### PR DESCRIPTION
Node.js `os.arch` and `process.arch` will report the version that Node.js was compiled for rather than the actual system architecture. Causes common cases of 32-bit Node.js installations running on a 64-bit system to require a needless rust compilation of native-clarity-bin