### PR TITLE
Potential fix for Windows package installation

### DIFF
--- a/packages/clarity-native-bin/package-lock.json
+++ b/packages/clarity-native-bin/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockstack/clarity-native-bin",
-	"version": "0.1.9-alpha.0",
+	"version": "0.1.10-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -127,6 +127,15 @@
 			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.7.tgz",
 			"integrity": "sha512-2Y8uPt0/jwjhQ6EiluT0XCri1Dbplr0ZxfFXUz+ye13gaqE8u5gL5ppao1JrUYr9cIip5S6MvQzBS7Kke7U9VA==",
 			"dev": true
+		},
+		"@types/fs-extra": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.0.0.tgz",
+			"integrity": "sha512-bCtL5v9zdbQW86yexOlXWTEGvLNqWxMFyi7gQA7Gcthbezr2cPSOb8SkESVKA937QD5cIwOFLDFt0MQoXOEr9Q==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
 		},
 		"@types/mocha": {
 			"version": "5.2.7",
@@ -606,6 +615,23 @@
 				}
 			}
 		},
+		"fs-extra": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+			"requires": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
+			},
+			"dependencies": {
+				"graceful-fs": {
+					"version": "4.2.2",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+					"integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q=="
+				}
+			}
+		},
 		"fs-minipass": {
 			"version": "1.2.6",
 			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
@@ -670,8 +696,7 @@
 		"graceful-fs": {
 			"version": "4.1.15",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-			"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
-			"dev": true
+			"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
 		},
 		"growl": {
 			"version": "1.10.5",
@@ -961,6 +986,14 @@
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
 			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
 			"dev": true
+		},
+		"jsonfile": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+			"requires": {
+				"graceful-fs": "^4.1.6"
+			}
 		},
 		"lcid": {
 			"version": "2.0.0",
@@ -1896,6 +1929,11 @@
 					"optional": true
 				}
 			}
+		},
+		"universalify": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
 		},
 		"uuid": {
 			"version": "3.3.2",

--- a/packages/clarity-native-bin/package.json
+++ b/packages/clarity-native-bin/package.json
@@ -30,12 +30,14 @@
     "postinstall": "node postInstallScript.js"
   },
   "dependencies": {
+    "fs-extra": "^8.0.1",
     "node-fetch": "^2.6.0",
     "semver": "^6.1.1",
     "tar": "^4.4.8"
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",
+    "@types/fs-extra": "^8.0.0",
     "@types/mocha": "^5.2.7",
     "@types/node": "^10",
     "@types/node-fetch": "^2.3.4",

--- a/packages/clarity-native-bin/src/fsUtil.ts
+++ b/packages/clarity-native-bin/src/fsUtil.ts
@@ -52,7 +52,7 @@ export function verifyOutputFile(
       logger.log(`Overwriting existing file: ${fullFilePath}`);
       fs.unlinkSync(fullFilePath);
     } else {
-      fs.mkdirSync(outputDirectory, { recursive: true });
+      fs.mkdirpSync(outputDirectory);
     }
     return true;
   } catch (error) {


### PR DESCRIPTION
Potential fix for https://github.com/blockstack/clarity-js-sdk/issues/44

* Fix missing `fs-extra` dependency in `clarity-native-bin`.
* Use `fs.mkdirp` to potentially fix issue with recursive path creation in Windows.