### PR TITLE
Updated release binaries

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.1.13-alpha.5"
+  "version": "0.1.13-alpha.6"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.1.13-alpha.4"
+  "version": "0.1.13-alpha.5"
 }

--- a/packages/clarity-cli/README.md
+++ b/packages/clarity-cli/README.md
@@ -10,7 +10,7 @@ $ npm install -g @blockstack/clarity-cli
 $ clarity COMMAND
 running command...
 $ clarity (-v|--version|version)
-@blockstack/clarity-cli/0.1.13-alpha.5 darwin-x64 node-v12.16.1
+@blockstack/clarity-cli/0.1.13-alpha.6 darwin-x64 node-v12.16.1
 $ clarity --help [COMMAND]
 USAGE
   $ clarity COMMAND

--- a/packages/clarity-cli/README.md
+++ b/packages/clarity-cli/README.md
@@ -10,7 +10,7 @@ $ npm install -g @blockstack/clarity-cli
 $ clarity COMMAND
 running command...
 $ clarity (-v|--version|version)
-@blockstack/clarity-cli/0.1.10-alpha.0 darwin-x64 node-v10.15.3
+@blockstack/clarity-cli/0.1.13-alpha.5 darwin-x64 node-v12.16.1
 $ clarity --help [COMMAND]
 USAGE
   $ clarity COMMAND
@@ -38,7 +38,7 @@ OPTIONS
   --all  see all commands in CLI
 ```
 
-_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v2.2.0/src/commands/help.ts)_
+_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v2.2.1/src/commands/help.ts)_
 
 ## `clarity new PROJECT`
 

--- a/packages/clarity-cli/package-lock.json
+++ b/packages/clarity-cli/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockstack/clarity-cli",
-	"version": "0.1.13-alpha.0",
+	"version": "0.1.13-alpha.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/clarity-cli/package-lock.json
+++ b/packages/clarity-cli/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockstack/clarity-cli",
-	"version": "0.1.13-alpha.4",
+	"version": "0.1.13-alpha.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/clarity-cli/package.json
+++ b/packages/clarity-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockstack/clarity-cli",
-  "version": "0.1.13-alpha.4",
+  "version": "0.1.13-alpha.5",
   "description": "The Clarity CLI is used to manage Clarity smart contracts from the command line.",
   "author": "Blockstack <engineering@blockstack.com> (https://blockstack.com/)",
   "license": "MIT",
@@ -50,13 +50,13 @@
     "test": "npm run build && nyc mocha"
   },
   "dependencies": {
-    "@blockstack/clarity": "^0.1.13-alpha.2",
-    "@blockstack/clarity-native-bin": "^0.1.13-alpha.2",
+    "@blockstack/clarity": "^0.1.13-alpha.5",
+    "@blockstack/clarity-native-bin": "^0.1.13-alpha.5",
     "@oclif/command": "^1.5.13",
     "@oclif/config": "^1.13.0",
     "@oclif/plugin-help": "^2.1.6",
     "fs-extra": "^8.0.1",
-    "generator-clarity-dev": "^0.1.13-alpha.4",
+    "generator-clarity-dev": "^0.1.13-alpha.5",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/packages/clarity-cli/package.json
+++ b/packages/clarity-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockstack/clarity-cli",
-  "version": "0.1.13-alpha.5",
+  "version": "0.1.13-alpha.6",
   "description": "The Clarity CLI is used to manage Clarity smart contracts from the command line.",
   "author": "Blockstack <engineering@blockstack.com> (https://blockstack.com/)",
   "license": "MIT",
@@ -50,13 +50,13 @@
     "test": "npm run build && nyc mocha"
   },
   "dependencies": {
-    "@blockstack/clarity": "^0.1.13-alpha.5",
-    "@blockstack/clarity-native-bin": "^0.1.13-alpha.5",
+    "@blockstack/clarity": "^0.1.13-alpha.6",
+    "@blockstack/clarity-native-bin": "^0.1.13-alpha.6",
     "@oclif/command": "^1.5.13",
     "@oclif/config": "^1.13.0",
     "@oclif/plugin-help": "^2.1.6",
     "fs-extra": "^8.0.1",
-    "generator-clarity-dev": "^0.1.13-alpha.5",
+    "generator-clarity-dev": "^0.1.13-alpha.6",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/packages/clarity-native-bin/package-lock.json
+++ b/packages/clarity-native-bin/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockstack/clarity-native-bin",
-	"version": "0.1.13-alpha.2",
+	"version": "0.1.13-alpha.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/clarity-native-bin/package-lock.json
+++ b/packages/clarity-native-bin/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockstack/clarity-native-bin",
-	"version": "0.1.13-alpha.0",
+	"version": "0.1.13-alpha.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/clarity-native-bin/package.json
+++ b/packages/clarity-native-bin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockstack/clarity-native-bin",
-  "version": "0.1.13-alpha.2",
+  "version": "0.1.13-alpha.5",
   "description": "Library for providing the native Clarity CLI binary",
   "author": "Blockstack <engineering@blockstack.com> (https://blockstack.com/)",
   "license": "MIT",

--- a/packages/clarity-native-bin/package.json
+++ b/packages/clarity-native-bin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockstack/clarity-native-bin",
-  "version": "0.1.13-alpha.5",
+  "version": "0.1.13-alpha.6",
   "description": "Library for providing the native Clarity CLI binary",
   "author": "Blockstack <engineering@blockstack.com> (https://blockstack.com/)",
   "license": "MIT",

--- a/packages/clarity-native-bin/src/index.ts
+++ b/packages/clarity-native-bin/src/index.ts
@@ -9,7 +9,7 @@ import { ConsoleLogger, ILogger } from "./logger";
  * Should correspond to both a git tag on the blockstack-core repo and a
  * set of clarity-binary distributables uploaded to the cloud storage endpoint.
  */
-export const CORE_SDK_TAG = "clarity-sdk-v0.0.5";
+export const CORE_SDK_TAG = "clarity-sdk-v0.0.6";
 
 export const BLOCKSTACK_CORE_SOURCE_TAG_ENV_VAR = "BLOCKSTACK_CORE_SOURCE_TAG";
 export const BLOCKSTACK_CORE_SOURCE_BRANCH_ENV_VAR = "BLOCKSTACK_CORE_SOURCE_BRANCH";

--- a/packages/clarity-tslint/package-lock.json
+++ b/packages/clarity-tslint/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockstack/clarity-tslint",
-	"version": "0.1.13-alpha.2",
+	"version": "0.1.13-alpha.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/clarity-tslint/package-lock.json
+++ b/packages/clarity-tslint/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockstack/clarity-tslint",
-	"version": "0.1.13-alpha.0",
+	"version": "0.1.13-alpha.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/clarity-tslint/package.json
+++ b/packages/clarity-tslint/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@blockstack/clarity-tslint",
   "description": "tslint rules for blockstack",
-  "version": "0.1.13-alpha.5",
+  "version": "0.1.13-alpha.6",
   "author": "Blockstack <engineering@blockstack.com> (https://blockstack.com/)",
   "devDependencies": {
     "shx": "^0.3.2",

--- a/packages/clarity-tslint/package.json
+++ b/packages/clarity-tslint/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@blockstack/clarity-tslint",
   "description": "tslint rules for blockstack",
-  "version": "0.1.13-alpha.2",
+  "version": "0.1.13-alpha.5",
   "author": "Blockstack <engineering@blockstack.com> (https://blockstack.com/)",
   "devDependencies": {
     "shx": "^0.3.2",

--- a/packages/clarity-tutorials/package-lock.json
+++ b/packages/clarity-tutorials/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockstack/clarity-tutorials",
-	"version": "0.1.13-alpha.2",
+	"version": "0.1.13-alpha.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/clarity-tutorials/package-lock.json
+++ b/packages/clarity-tutorials/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockstack/clarity-tutorials",
-	"version": "0.1.13-alpha.0",
+	"version": "0.1.13-alpha.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/clarity-tutorials/package.json
+++ b/packages/clarity-tutorials/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockstack/clarity-tutorials",
-  "version": "0.1.13-alpha.2",
+  "version": "0.1.13-alpha.5",
   "description": "Getting started with Clarity",
   "author": "Blockstack <engineering@blockstack.com> (https://blockstack.com/)",
   "license": "MIT",
@@ -35,8 +35,8 @@
     "/contracts"
   ],
   "dependencies": {
-    "@blockstack/clarity": "^0.1.13-alpha.2",
-    "@blockstack/clarity-native-bin": "^0.1.13-alpha.2"
+    "@blockstack/clarity": "^0.1.13-alpha.5",
+    "@blockstack/clarity-native-bin": "^0.1.13-alpha.5"
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",

--- a/packages/clarity-tutorials/package.json
+++ b/packages/clarity-tutorials/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockstack/clarity-tutorials",
-  "version": "0.1.13-alpha.5",
+  "version": "0.1.13-alpha.6",
   "description": "Getting started with Clarity",
   "author": "Blockstack <engineering@blockstack.com> (https://blockstack.com/)",
   "license": "MIT",
@@ -35,8 +35,8 @@
     "/contracts"
   ],
   "dependencies": {
-    "@blockstack/clarity": "^0.1.13-alpha.5",
-    "@blockstack/clarity-native-bin": "^0.1.13-alpha.5"
+    "@blockstack/clarity": "^0.1.13-alpha.6",
+    "@blockstack/clarity-native-bin": "^0.1.13-alpha.6"
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",

--- a/packages/clarity/package-lock.json
+++ b/packages/clarity/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockstack/clarity",
-	"version": "0.1.13-alpha.0",
+	"version": "0.1.13-alpha.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/clarity/package-lock.json
+++ b/packages/clarity/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockstack/clarity",
-	"version": "0.1.13-alpha.2",
+	"version": "0.1.13-alpha.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/clarity/package.json
+++ b/packages/clarity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockstack/clarity",
-  "version": "0.1.13-alpha.2",
+  "version": "0.1.13-alpha.5",
   "description": "Clarity JS SDK - Core library",
   "author": "Blockstack <engineering@blockstack.com> (https://blockstack.com/)",
   "license": "MIT",
@@ -36,7 +36,7 @@
     "@blockstack/clarity-native-bin": "^0.1.10-alpha.0"
   },
   "devDependencies": {
-    "@blockstack/clarity-native-bin": "^0.1.13-alpha.2",
+    "@blockstack/clarity-native-bin": "^0.1.13-alpha.5",
     "@types/chai": "^4.1.7",
     "@types/mocha": "^5.2.7",
     "@types/node": "^10",

--- a/packages/clarity/package.json
+++ b/packages/clarity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockstack/clarity",
-  "version": "0.1.13-alpha.5",
+  "version": "0.1.13-alpha.6",
   "description": "Clarity JS SDK - Core library",
   "author": "Blockstack <engineering@blockstack.com> (https://blockstack.com/)",
   "license": "MIT",
@@ -36,7 +36,7 @@
     "@blockstack/clarity-native-bin": "^0.1.10-alpha.0"
   },
   "devDependencies": {
-    "@blockstack/clarity-native-bin": "^0.1.13-alpha.5",
+    "@blockstack/clarity-native-bin": "^0.1.13-alpha.6",
     "@types/chai": "^4.1.7",
     "@types/mocha": "^5.2.7",
     "@types/node": "^10",

--- a/packages/clarity/src/providers/clarityBin/index.ts
+++ b/packages/clarity/src/providers/clarityBin/index.ts
@@ -43,7 +43,13 @@ export class NativeClarityBinProvider implements Provider {
   static async createEphemeral(clarityBinPath: string): Promise<Provider> {
     const tempDbPath = getTempFilePath("blockstack-local-{uniqueID}.db");
     const instance = await this.create(tempDbPath, clarityBinPath);
-    instance.closeActions.push(() => fs.unlinkSync(instance.dbFilePath));
+    instance.closeActions.push(() => {
+      try {
+        fs.unlinkSync(instance.dbFilePath);
+      } catch (error) {
+        // console.error(error);
+      }
+    });
     return instance;
   }
 

--- a/packages/create-clarity-dev/package-lock.json
+++ b/packages/create-clarity-dev/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "create-clarity-dev",
-	"version": "0.1.13-alpha.4",
+	"version": "0.1.13-alpha.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/create-clarity-dev/package-lock.json
+++ b/packages/create-clarity-dev/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "create-clarity-dev",
-	"version": "0.1.13-alpha.0",
+	"version": "0.1.13-alpha.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/create-clarity-dev/package.json
+++ b/packages/create-clarity-dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-clarity-dev",
-  "version": "0.1.13-alpha.4",
+  "version": "0.1.13-alpha.5",
   "description": "An npm initializer to setup a Clarity development environment",
   "author": "Blockstack <engineering@blockstack.com> (https://blockstack.com/)",
   "license": "MIT",
@@ -39,7 +39,7 @@
     "/cmd"
   ],
   "dependencies": {
-    "generator-clarity-dev": "^0.1.13-alpha.4"
+    "generator-clarity-dev": "^0.1.13-alpha.5"
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",

--- a/packages/create-clarity-dev/package.json
+++ b/packages/create-clarity-dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-clarity-dev",
-  "version": "0.1.13-alpha.5",
+  "version": "0.1.13-alpha.6",
   "description": "An npm initializer to setup a Clarity development environment",
   "author": "Blockstack <engineering@blockstack.com> (https://blockstack.com/)",
   "license": "MIT",
@@ -39,7 +39,7 @@
     "/cmd"
   ],
   "dependencies": {
-    "generator-clarity-dev": "^0.1.13-alpha.5"
+    "generator-clarity-dev": "^0.1.13-alpha.6"
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",

--- a/packages/generator-clarity-dev/package-lock.json
+++ b/packages/generator-clarity-dev/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "generator-clarity-dev",
-	"version": "0.1.13-alpha.4",
+	"version": "0.1.13-alpha.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/generator-clarity-dev/package-lock.json
+++ b/packages/generator-clarity-dev/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "generator-clarity-dev",
-	"version": "0.1.13-alpha.0",
+	"version": "0.1.13-alpha.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/generator-clarity-dev/package.json
+++ b/packages/generator-clarity-dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-clarity-dev",
-  "version": "0.1.13-alpha.5",
+  "version": "0.1.13-alpha.6",
   "description": "Yeoman generator to setup a Clarity development environment",
   "author": "Blockstack <engineering@blockstack.com> (https://blockstack.com/)",
   "license": "MIT",
@@ -35,8 +35,8 @@
     "test": "npm run build && nyc mocha"
   },
   "dependencies": {
-    "@blockstack/clarity": "^0.1.13-alpha.5",
-    "@blockstack/clarity-native-bin": "^0.1.13-alpha.5",
+    "@blockstack/clarity": "^0.1.13-alpha.6",
+    "@blockstack/clarity-native-bin": "^0.1.13-alpha.6",
     "github-username": "^5.0.1",
     "semver": "^6.1.1",
     "yeoman-generator": "^4.0.1"

--- a/packages/generator-clarity-dev/package.json
+++ b/packages/generator-clarity-dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-clarity-dev",
-  "version": "0.1.13-alpha.4",
+  "version": "0.1.13-alpha.5",
   "description": "Yeoman generator to setup a Clarity development environment",
   "author": "Blockstack <engineering@blockstack.com> (https://blockstack.com/)",
   "license": "MIT",
@@ -35,8 +35,8 @@
     "test": "npm run build && nyc mocha"
   },
   "dependencies": {
-    "@blockstack/clarity": "^0.1.13-alpha.2",
-    "@blockstack/clarity-native-bin": "^0.1.13-alpha.2",
+    "@blockstack/clarity": "^0.1.13-alpha.5",
+    "@blockstack/clarity-native-bin": "^0.1.13-alpha.5",
     "github-username": "^5.0.1",
     "semver": "^6.1.1",
     "yeoman-generator": "^4.0.1"


### PR DESCRIPTION
2 things in this PR:

- Adds a try/catch to `createEphemeral` in the provider. I'm not 100% sure how this works, but I think we don't need to create an ephemeral folder anymore.
- Version bump

I also published `0.1.13-alpha.5` on NPM.