### PR TITLE
reject `checkContract` if check was not successful

### DIFF
--- a/packages/clarity/src/core/client.ts
+++ b/packages/clarity/src/core/client.ts
@@ -15,8 +15,13 @@ export class Client {
   }
 
   checkContract = async (): Promise<void> => {
-    await this.provider.checkContract(this.filePath);
-  }
+    const checkResult = await this.provider.checkContract(this.filePath);
+    if (!checkResult.success) {
+      return Promise.reject();
+    } else {
+      return Promise.resolve();
+    }
+  };
 
   deployContract = async (): Promise<Receipt> => {
     const receipt = await this.provider.launchContract(this.name, this.filePath);


### PR DESCRIPTION
This PR
* inspects the `CheckResult` of `Provider.checkContract` and returns only a resolvable promise when the check result was successful.
* fixes #69 

This change makes the `RocketFactory` Test  Suite fail due to
```
Error (line 113, column 1): use of unresolved contract \'S1G2081040G2081040G2081040G208105NK8PE5.rocket-token\'.\n' }
```