### PR TITLE
Add init allocs when creating default provider

### DIFF
--- a/packages/clarity/src/core/provider.ts
+++ b/packages/clarity/src/core/provider.ts
@@ -1,7 +1,8 @@
 import { CheckResult, Receipt } from ".";
+import { InitialAllocation } from "../providers/clarityBin";
 
 export interface ProviderConstructor {
-  create(): Promise<Provider>;
+  create(allocations: InitialAllocation[]): Promise<Provider>;
 }
 
 export interface Provider {

--- a/packages/clarity/src/providers/clarityBin/index.ts
+++ b/packages/clarity/src/providers/clarityBin/index.ts
@@ -39,7 +39,9 @@ export class NativeClarityBinProvider implements Provider {
   /**
    * Instantiates a new executor pointed at a new temporary database file.
    * The temp file is deleted when `close` is invoked.
-   * Before returning, ensures db is ready with `initialize`.
+   * Before returning, ensures db is ready with `initialize`.   *
+   * @param allocations initializes the given accounts with amount of STXs at start.
+   * @param clarityBinPath file path to the clarity binary, can be `getDefaultBinaryFilePath`.
    */
   static async createEphemeral(
     allocations: InitialAllocation[],

--- a/packages/clarity/src/providers/clarityBin/index.ts
+++ b/packages/clarity/src/providers/clarityBin/index.ts
@@ -41,9 +41,12 @@ export class NativeClarityBinProvider implements Provider {
    * The temp file is deleted when `close` is invoked.
    * Before returning, ensures db is ready with `initialize`.
    */
-  static async createEphemeral(clarityBinPath: string): Promise<Provider> {
+  static async createEphemeral(
+    allocations: InitialAllocation[],
+    clarityBinPath: string
+  ): Promise<Provider> {
     const tempDbPath = getTempFilePath("blockstack-local-{uniqueID}.db");
-    const instance = await this.create([], tempDbPath, clarityBinPath);
+    const instance = await this.create(allocations, tempDbPath, clarityBinPath);
     instance.closeActions.push(() => {
       try {
         fs.unlinkSync(instance.dbFilePath);

--- a/packages/clarity/src/providers/registry.ts
+++ b/packages/clarity/src/providers/registry.ts
@@ -66,6 +66,8 @@ export class ProviderRegistry {
 
   /**
    * Creates an instance of the last registered provider.
+   * @param allocations initializes the given accounts with
+   * amount of STXs at start. Defaults to empty list.
    * @param noWarn Set to true to disable warning log about multiple registered providers.
    */
   static async createProvider(

--- a/packages/clarity/src/providers/registry.ts
+++ b/packages/clarity/src/providers/registry.ts
@@ -52,7 +52,7 @@ export class ProviderRegistry {
         }
         const nativeBinFile = nativeBinModule.getDefaultBinaryFilePath();
         const providerConstructor: ProviderConstructor = {
-          create: () => NativeClarityBinProvider.createEphemeral(nativeBinFile)
+          create: () => NativeClarityBinProvider.createEphemeral([], nativeBinFile),
         };
         // Reset the cached promise so that future invocations have the chance to retry.
         this.defaultLoadCachedPromise = undefined;

--- a/packages/clarity/src/providers/registry.ts
+++ b/packages/clarity/src/providers/registry.ts
@@ -1,5 +1,5 @@
 import { Provider, ProviderConstructor } from "../core/provider";
-import { NativeClarityBinProvider } from "./clarityBin";
+import { InitialAllocation, NativeClarityBinProvider } from "./clarityBin";
 
 export class ProviderRegistry {
   static availableProviders: ProviderConstructor[] = [];
@@ -52,7 +52,8 @@ export class ProviderRegistry {
         }
         const nativeBinFile = nativeBinModule.getDefaultBinaryFilePath();
         const providerConstructor: ProviderConstructor = {
-          create: () => NativeClarityBinProvider.createEphemeral([], nativeBinFile),
+          create: (allocations) =>
+            NativeClarityBinProvider.createEphemeral(allocations, nativeBinFile),
         };
         // Reset the cached promise so that future invocations have the chance to retry.
         this.defaultLoadCachedPromise = undefined;
@@ -67,7 +68,10 @@ export class ProviderRegistry {
    * Creates an instance of the last registered provider.
    * @param noWarn Set to true to disable warning log about multiple registered providers.
    */
-  static async createProvider(noWarn = false): Promise<Provider> {
+  static async createProvider(
+    allocations: InitialAllocation[] = [],
+    noWarn = false
+  ): Promise<Provider> {
     if (this.availableProviders.length === 0) {
       const defaultProvider = await this.tryLoadDefaultBinProvider();
       if (defaultProvider === false) {
@@ -86,7 +90,7 @@ export class ProviderRegistry {
     }
     // Return the last registered provider
     const providerConstructor = this.availableProviders[this.availableProviders.length - 1];
-    return providerConstructor.create();
+    return providerConstructor.create(allocations);
   }
 
   private constructor() {}

--- a/packages/clarity/test/nativeClarityBinProvider.ts
+++ b/packages/clarity/test/nativeClarityBinProvider.ts
@@ -8,7 +8,7 @@ const clarityBinPath = getDefaultBinaryFilePath();
 
 describe("NativeClarityBinProvider", () => {
   it("create ephemeral", async () => {
-    const provider = await NativeClarityBinProvider.createEphemeral(clarityBinPath);
+    const provider = await NativeClarityBinProvider.createEphemeral([], clarityBinPath);
     assert.isDefined(provider);
   });
 


### PR DESCRIPTION
## Description

As a developer, I want to easily add initial allocations.

This PR adds 
* a new argument `allocations` to `ProviderRegistry.createProvider`

Currently, this is only supported for the clarity bin provider.

Example:
As a Blockstack developer, I would like to encrypt files using the app private key. This is needed because storing unencrypted files is unacceptable. This pull request adds the `encryptContent` function which will take a string and encrypt it using the app private key.

```
const providerWithZeroAllocations = await ProviderRegistry.createProvider();
const providerWithOneAllocations = await ProviderRegistry.createProvider([{principal: "SP3GWX3NE58KXHESRYE4DYQ1S31PQJTCRXB3PE9SB", amount: 1000}]);
```

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
There is no clarity js sdk guide yet

## Testing information
Test already existed

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [x] Changelog is updated
- [x] Tag 1 of @hstove 
