### PR TITLE
Update clarity binaries and fix compile from source

### DIFF
--- a/packages/clarity-cli/package-lock.json
+++ b/packages/clarity-cli/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockstack/clarity-cli",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/clarity-native-bin/package-lock.json
+++ b/packages/clarity-native-bin/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockstack/clarity-native-bin",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -183,6 +183,15 @@
 				"@types/node": "*"
 			}
 		},
+		"@types/unzipper": {
+			"version": "0.10.3",
+			"resolved": "https://registry.npmjs.org/@types/unzipper/-/unzipper-0.10.3.tgz",
+			"integrity": "sha512-01mQdTLp3/KuBVDhP82FNBf+enzVOjJ9dGsCWa5z8fcYAFVgA9bqIQ2NmsgNFzN/DhD0PUQj4n5p7k6I9mq80g==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"ansi-colors": {
 			"version": "3.2.3",
 			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
@@ -243,14 +252,31 @@
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-			"dev": true
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+		},
+		"big-integer": {
+			"version": "1.6.48",
+			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
+			"integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w=="
+		},
+		"binary": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+			"integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
+			"requires": {
+				"buffers": "~0.1.1",
+				"chainsaw": "~0.1.0"
+			}
+		},
+		"bluebird": {
+			"version": "3.4.7",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+			"integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM="
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -267,6 +293,16 @@
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
 			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
 			"dev": true
+		},
+		"buffer-indexof-polyfill": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+			"integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A=="
+		},
+		"buffers": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+			"integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s="
 		},
 		"builtin-modules": {
 			"version": "1.1.1",
@@ -304,6 +340,14 @@
 				"get-func-name": "^2.0.0",
 				"pathval": "^1.1.0",
 				"type-detect": "^4.0.5"
+			}
+		},
+		"chainsaw": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+			"integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
+			"requires": {
+				"traverse": ">=0.3.0 <0.4"
 			}
 		},
 		"chalk": {
@@ -386,8 +430,7 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"convert-source-map": {
 			"version": "1.6.0",
@@ -405,6 +448,11 @@
 					"dev": true
 				}
 			}
+		},
+		"core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
 		"cp-file": {
 			"version": "6.2.0",
@@ -487,6 +535,14 @@
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
 			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
 			"dev": true
+		},
+		"duplexer2": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+			"integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+			"requires": {
+				"readable-stream": "^2.0.2"
+			}
 		},
 		"emoji-regex": {
 			"version": "7.0.3",
@@ -658,8 +714,18 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+		},
+		"fstream": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+			"integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+			"requires": {
+				"graceful-fs": "^4.1.2",
+				"inherits": "~2.0.0",
+				"mkdirp": ">=0.5 0",
+				"rimraf": "2"
+			}
 		},
 		"function-bind": {
 			"version": "1.1.1",
@@ -692,7 +758,6 @@
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
 			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -804,7 +869,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -813,8 +877,7 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"interpret": {
 			"version": "1.2.0",
@@ -881,6 +944,11 @@
 			"requires": {
 				"has-symbols": "^1.0.0"
 			}
+		},
+		"isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -1024,6 +1092,11 @@
 				"invert-kv": "^2.0.0"
 			}
 		},
+		"listenercount": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+			"integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc="
+		},
 		"load-json-file": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -1164,7 +1237,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -1383,7 +1455,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -1478,8 +1549,7 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"path-key": {
 			"version": "2.0.1",
@@ -1531,6 +1601,11 @@
 				"find-up": "^3.0.0"
 			}
 		},
+		"process-nextick-args": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+		},
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -1566,6 +1641,27 @@
 			"requires": {
 				"find-up": "^3.0.0",
 				"read-pkg": "^3.0.0"
+			}
+		},
+		"readable-stream": {
+			"version": "2.3.7",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+			"requires": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+				}
 			}
 		},
 		"rechoir": {
@@ -1617,7 +1713,6 @@
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
 			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-			"dev": true,
 			"requires": {
 				"glob": "^7.1.3"
 			}
@@ -1637,6 +1732,11 @@
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
 			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 			"dev": true
+		},
+		"setimmediate": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
 		},
 		"shebang-command": {
 			"version": "1.2.0",
@@ -1795,6 +1895,21 @@
 				"function-bind": "^1.0.2"
 			}
 		},
+		"string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"requires": {
+				"safe-buffer": "~5.1.0"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+				}
+			}
+		},
 		"strip-ansi": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -1862,6 +1977,11 @@
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
 			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
 			"dev": true
+		},
+		"traverse": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+			"integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk="
 		},
 		"trim-right": {
 			"version": "1.0.1",
@@ -1971,6 +2091,28 @@
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
 			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
 		},
+		"unzipper": {
+			"version": "0.10.11",
+			"resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
+			"integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
+			"requires": {
+				"big-integer": "^1.6.17",
+				"binary": "~0.3.0",
+				"bluebird": "~3.4.1",
+				"buffer-indexof-polyfill": "~1.0.0",
+				"duplexer2": "~0.1.4",
+				"fstream": "^1.0.12",
+				"graceful-fs": "^4.2.2",
+				"listenercount": "~1.0.1",
+				"readable-stream": "~2.3.6",
+				"setimmediate": "~1.0.4"
+			}
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+		},
 		"uuid": {
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
@@ -2061,8 +2203,7 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"write-file-atomic": {
 			"version": "2.4.3",

--- a/packages/clarity-native-bin/package-lock.json
+++ b/packages/clarity-native-bin/package-lock.json
@@ -137,15 +137,6 @@
 				"@types/node": "*"
 			}
 		},
-		"@types/minipass": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@types/minipass/-/minipass-2.2.0.tgz",
-			"integrity": "sha512-wuzZksN4w4kyfoOv/dlpov4NOunwutLA/q7uc00xU02ZyUY+aoM5PWIXEKBMnm0NHd4a+N71BMjq+x7+2Af1fg==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*"
-			}
-		},
 		"@types/mocha": {
 			"version": "5.2.7",
 			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
@@ -172,16 +163,6 @@
 			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.0.1.tgz",
 			"integrity": "sha512-ffCdcrEE5h8DqVxinQjo+2d1q+FV5z7iNtPofw3JsrltSoSVlOGaW0rY8XxtO9XukdTn8TaCGWmk2VFGhI70mg==",
 			"dev": true
-		},
-		"@types/tar": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/@types/tar/-/tar-4.0.3.tgz",
-			"integrity": "sha512-Z7AVMMlkI8NTWF0qGhC4QIX0zkV/+y0J8x7b/RsHrN0310+YNjoJd8UrApCiGBCWtKjxS9QhNqLi2UJNToh5hA==",
-			"dev": true,
-			"requires": {
-				"@types/minipass": "*",
-				"@types/node": "*"
-			}
 		},
 		"@types/unzipper": {
 			"version": "0.10.3",
@@ -377,11 +358,6 @@
 			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
 			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
 			"dev": true
-		},
-		"chownr": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
-			"integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A=="
 		},
 		"cliui": {
 			"version": "4.1.0",
@@ -701,14 +677,6 @@
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^4.0.0",
 				"universalify": "^0.1.0"
-			}
-		},
-		"fs-minipass": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
-			"integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
-			"requires": {
-				"minipass": "^2.2.1"
 			}
 		},
 		"fs.realpath": {
@@ -1246,23 +1214,6 @@
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
 			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 		},
-		"minipass": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.5.0.tgz",
-			"integrity": "sha512-9FwMVYhn6ERvMR8XFdOavRz4QK/VJV8elU1x50vYexf9lslDcWe/f4HBRxCPd185ekRSjU6CfYyJCECa/CQy7Q==",
-			"requires": {
-				"safe-buffer": "^5.1.2",
-				"yallist": "^3.0.0"
-			}
-		},
-		"minizlib": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
-			"integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
-			"requires": {
-				"minipass": "^2.2.1"
-			}
-		},
 		"mkdirp": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -1720,7 +1671,8 @@
 		"safe-buffer": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-			"integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+			"integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+			"dev": true
 		},
 		"semver": {
 			"version": "6.3.0",
@@ -1944,20 +1896,6 @@
 			"dev": true,
 			"requires": {
 				"has-flag": "^3.0.0"
-			}
-		},
-		"tar": {
-			"version": "4.4.10",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.10.tgz",
-			"integrity": "sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==",
-			"requires": {
-				"chownr": "^1.1.1",
-				"fs-minipass": "^1.2.5",
-				"minipass": "^2.3.5",
-				"minizlib": "^1.2.1",
-				"mkdirp": "^0.5.0",
-				"safe-buffer": "^5.1.2",
-				"yallist": "^3.0.3"
 			}
 		},
 		"test-exclude": {
@@ -2221,11 +2159,6 @@
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
 			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
 			"dev": true
-		},
-		"yallist": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-			"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
 		},
 		"yargs": {
 			"version": "13.2.2",

--- a/packages/clarity-native-bin/package.json
+++ b/packages/clarity-native-bin/package.json
@@ -39,7 +39,6 @@
     "fs-extra": "^8.0.1",
     "node-fetch": "^2.6.0",
     "semver": "^6.1.1",
-    "tar": "^4.4.8",
     "unzipper": "^0.10.11"
   },
   "devDependencies": {
@@ -49,7 +48,6 @@
     "@types/node": "^10",
     "@types/node-fetch": "^2.3.4",
     "@types/semver": "^6.0.1",
-    "@types/tar": "^4.0.0",
     "@types/unzipper": "^0.10.3",
     "chai": "^4.2.0",
     "mocha": "^6.1.4",

--- a/packages/clarity-native-bin/package.json
+++ b/packages/clarity-native-bin/package.json
@@ -39,7 +39,8 @@
     "fs-extra": "^8.0.1",
     "node-fetch": "^2.6.0",
     "semver": "^6.1.1",
-    "tar": "^4.4.8"
+    "tar": "^4.4.8",
+    "unzipper": "^0.10.11"
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",
@@ -49,6 +50,7 @@
     "@types/node-fetch": "^2.3.4",
     "@types/semver": "^6.0.1",
     "@types/tar": "^4.0.0",
+    "@types/unzipper": "^0.10.3",
     "chai": "^4.2.0",
     "mocha": "^6.1.4",
     "nyc": "^14.1.1",

--- a/packages/clarity-native-bin/src/cargoBuild.ts
+++ b/packages/clarity-native-bin/src/cargoBuild.ts
@@ -26,6 +26,7 @@ export async function cargoInstall(opts: {
   logger: ILogger;
   overwriteExisting: boolean;
   outputFilePath: string;
+  buildPackage: string;
   gitBranch?: string;
   gitTag?: string;
   gitCommitHash?: string;
@@ -61,7 +62,8 @@ export async function cargoInstall(opts: {
     ...gitSpecifierOpts,
     "--bin=clarity-cli",
     "--root",
-    tempCompileDir
+    tempCompileDir,
+    opts.buildPackage
   ];
   if (opts.overwriteExisting) {
     args.push("--force");

--- a/packages/clarity-native-bin/src/fetchDist.ts
+++ b/packages/clarity-native-bin/src/fetchDist.ts
@@ -14,7 +14,7 @@ const DIST_DOWNLOAD_URL_TEMPLATE =
   "download/{tag}/{platform}-{arch}.zip";
 
 const enum SupportedDistPlatform {
-  WINDOWS = "win",
+  WINDOWS = "windows",
   MACOS = "macos",
   LINUX = "linux",
   LINUX_MUSL = "linux-musl"

--- a/packages/clarity-native-bin/src/fetchDist.ts
+++ b/packages/clarity-native-bin/src/fetchDist.ts
@@ -2,7 +2,6 @@ import * as fs from "fs-extra";
 import fetch from "node-fetch";
 import * as os from "os";
 import * as path from "path";
-import * as tar from "tar";
 import * as unzip from "unzipper";
 import { detectArch } from "./detectArch";
 import { detectLibc } from "./detectLibc";

--- a/packages/clarity-native-bin/src/index.ts
+++ b/packages/clarity-native-bin/src/index.ts
@@ -9,7 +9,7 @@ import { ConsoleLogger, ILogger } from "./logger";
  * Should correspond to both a git tag on the blockstack-core repo and a
  * set of clarity-binary distributables uploaded to the cloud storage endpoint.
  */
-export const CORE_SDK_TAG = "clarity-sdk-v0.1.2";
+export const CORE_SDK_TAG = "v23.0.0.12-krypton";
 
 export const BLOCKSTACK_CORE_SOURCE_TAG_ENV_VAR = "BLOCKSTACK_CORE_SOURCE_TAG";
 export const BLOCKSTACK_CORE_SOURCE_BRANCH_ENV_VAR = "BLOCKSTACK_CORE_SOURCE_BRANCH";

--- a/packages/clarity-native-bin/src/index.ts
+++ b/packages/clarity-native-bin/src/index.ts
@@ -110,6 +110,7 @@ export async function installDefaultPath(): Promise<boolean> {
       logger: logger,
       overwriteExisting: true,
       outputFilePath: installPath,
+      buildPackage: "blockstack-core",
       gitBranch: versionBranch,
       gitTag: versionTag,
     });
@@ -143,7 +144,7 @@ export async function install(opts: {
     return false;
   }
   if (opts.fromSource) {
-    return cargoInstall({ ...opts, gitTag: opts.versionTag });
+    return cargoInstall({ ...opts, buildPackage: "blockstack-core", gitTag: opts.versionTag });
   } else {
     return fetchDistributable(opts);
   }

--- a/packages/clarity-tslint/package-lock.json
+++ b/packages/clarity-tslint/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockstack/clarity-tslint",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/clarity-tutorials/package-lock.json
+++ b/packages/clarity-tutorials/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockstack/clarity-tutorials",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/clarity-tutorials/test/samples/hello-world.test.ts
+++ b/packages/clarity-tutorials/test/samples/hello-world.test.ts
@@ -21,7 +21,7 @@ describe("hello world contract test suite", () => {
     it("should return 'hello world'", async () => {
       const query = helloWorldClient.createQuery({ method: { name: "say-hi", args: [] } });
       const receipt = await helloWorldClient.submitQuery(query);
-      const result = Result.unwrapString(receipt);
+      const result = Result.unwrapString(receipt, "utf8");
       expect(result).toEqual("hello world");
     });
 

--- a/packages/clarity/package-lock.json
+++ b/packages/clarity/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockstack/clarity",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/clarity/src/core/result.ts
+++ b/packages/clarity/src/core/result.ts
@@ -98,9 +98,16 @@ export function unwrapInt(input: ResultInterface<string, unknown>): number {
   return parseInt(match);
 }
 
-export function unwrapString(input: ResultInterface<string, unknown>): string {
-  const match = getWrappedResult(input, /^\(ok\s0x(\w+)\)$/);
-  return Buffer.from(match, "hex").toString();
+export function unwrapString(input: ResultInterface<string, unknown>, encoding = "hex"): string {
+  let match;
+  if (encoding === "hex") {
+    match = getWrappedResult(input, /^\(ok\s0x(\w+)\)$/);
+  } else if (encoding === "utf8") {
+    match = getWrappedResult(input, /^\(ok\s\"(.+)\"\)$/);
+  } else {
+    match = getWrappedResult(input, /^\(ok\s(.+)\)$/);
+  }
+  return Buffer.from(match, encoding).toString();
 }
 
 export const Result = {

--- a/packages/create-clarity-starter/package-lock.json
+++ b/packages/create-clarity-starter/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "create-clarity-starter",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/generator-clarity-dev/generators/app/templates/test/hello-world.ts_template
+++ b/packages/generator-clarity-dev/generators/app/templates/test/hello-world.ts_template
@@ -22,7 +22,7 @@ describe("hello world contract test suite", () => {
     it("should return 'hello world'", async () => {
       const query = helloWorldClient.createQuery({ method: { name: "say-hi", args: [] } });
       const receipt = await helloWorldClient.submitQuery(query);
-      const result = Result.unwrapString(receipt);
+      const result = Result.unwrapString(receipt, "utf8");
       assert.equal(result, "hello world");
     });
 

--- a/packages/generator-clarity-dev/package-lock.json
+++ b/packages/generator-clarity-dev/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "generator-clarity-dev",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {


### PR DESCRIPTION
## Description

Updates the `clarity-native-bin` package to pull the binary down from the `stacks-blockchain` repo, from the current latest release. Also fixes the ability to compile and install the binary from source via command:
`BLOCKSTACK_CORE_SOURCE_BRANCH="master" npm install`

Closes #119 
Implementing this should also help move us towards completing #99 
## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] API reference/documentation update
- [X] Other

## Does this introduce a breaking change?
I don't believe so.

## Are documentation updates required?
No

## Testing information

Tests via `npm run rebuild && npm run test` fail in this [`hello-world` test](https://github.com/blockstack/clarity-js-sdk/blob/update-clarity-binaries/packages/clarity-tutorials/test/samples/hello-world.test.ts#L21-L26) for clarity-tutorials and I can't seem to get to the bottom of it. The error is as follows:
```
  ● hello world contract test suite › deploying an instance of the contract › should return 'hello world'

    Unable to unwrap result: (ok "hello world")
```

@hstove Are you able to take a look at why this test is failing? I'm not familiar with the code and it looks like you were working on that test last.

To reproduce the bug for compiling from source, just run `BLOCKSTACK_CORE_SOURCE_BRANCH="master" npm install` on the master branch.

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `npm run test` passes
- [ ] Changelog is updated
- [X] Tag 2 of @hstove and @zone117x 
