### PR TITLE
chore: fix version and publish steps

### DIFF
--- a/.github/workflows/clarity-js-sdk.yml
+++ b/.github/workflows/clarity-js-sdk.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   notify-start:
     runs-on: ubuntu-latest
-    # Only run on non-PR events or only PRs that aren't from forks 
+    # Only run on non-PR events or only PRs that aren't from forks
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     outputs:
       slack_message_id: ${{ steps.slack.outputs.message_id }}
@@ -86,14 +86,14 @@ jobs:
         if: github.ref == 'refs/heads/master'
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
-        run: "lerna version --yes --conventional-commits --create-release github --message 'chore(release): publish %s'"
+        run: "npm run version"
 
       - name: Publish
         # Only run on master branch
         if: github.ref == 'refs/heads/master'
         env:
           NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-        run: "lerna publish --yes --conventional-commits --create-release github --message 'chore(release): publish %s'"
+        run: "npm run pub"
 
   notify-end:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   },
   "license": "MIT",
   "scripts": {
-    "version-bump": "lerna version",
-    "version-bump-no-push": "lerna version --force-publish --no-push prerelease",
-    "pub": "lerna publish from-package",
+    "version": "lerna version --yes --conventional-commits --create-release github --message 'chore(release): publish %s'",
+    "version-no-push": "lerna version --conventional-commits --force-publish --no-push --conventional-prerelease",
+    "pub": "lerna publish from-package --yes",
     "prepare": "lerna bootstrap",
     "clean": "lerna run clean && lerna clean --yes",
     "build": "lerna run build",


### PR DESCRIPTION
## Description

Fixes a bug in the GH action workflow to use `npm run <script>` because `lerna` commands cannot be used directly after `npm install` without installing it globally.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [X] Other

## Does this introduce a breaking change?
No

## Checklist
- [X] Tag 1 of @person1 or @person2
