### PR TITLE
Feat/check contract with contract ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## Unreleased
+
+### Fixed
+
+* Enable `checkContract()` to succeed with short-hand contract identifiers.
+
 ## 0.3.7 (2021-01-06)
 
 **Note:** Version bump only for package clarity-monorepo-wrapper

--- a/packages/clarity/src/core/client.ts
+++ b/packages/clarity/src/core/client.ts
@@ -15,7 +15,7 @@ export class Client {
   }
 
   checkContract = async (): Promise<void> => {
-    const checkResult = await this.provider.checkContract(this.filePath);
+    const checkResult = await this.provider.checkContract(this.filePath, this.name);
     if (!checkResult.success) {
       throw new Error(checkResult.error);
     }

--- a/packages/clarity/src/core/provider.ts
+++ b/packages/clarity/src/core/provider.ts
@@ -7,7 +7,7 @@ export interface ProviderConstructor {
 export interface Provider {
   initialize(): Promise<void>;
 
-  checkContract(contractFilePath: string): Promise<CheckResult>;
+  checkContract(contractFilePath: string, contractId?: string): Promise<CheckResult>;
 
   launchContract(contractName: string, contractFilePath: string): Promise<Receipt>;
 

--- a/packages/clarity/src/providers/blockstackCoreBin/index.ts.old
+++ b/packages/clarity/src/providers/blockstackCoreBin/index.ts.old
@@ -253,7 +253,7 @@ export class CargoBuildProvider implements Provider {
     }
   }
 
-  async checkContract(contractFilePath: string): Promise<Receipt> {
+  async checkContract(contractFilePath: string, contractId?: string): Promise<Receipt> {
     const filePath = getContractFilePath(contractFilePath);
     const result = await this.cargoRunLocal([
       "check",

--- a/packages/clarity/src/providers/clarityBin/index.ts
+++ b/packages/clarity/src/providers/clarityBin/index.ts
@@ -107,9 +107,13 @@ export class NativeClarityBinProvider implements Provider {
     }
   }
 
-  async checkContract(contractFilePath: string): Promise<CheckResult> {
+  async checkContract(contractFilePath: string, contractId?: string): Promise<CheckResult> {
     const filePath = getNormalizedContractFilePath(contractFilePath);
-    const result = await this.runCommand(["check", filePath, this.dbFilePath, "--output_analysis"]);
+    let args = ["check", filePath, this.dbFilePath, "--output_analysis"];
+    if (contractId !== undefined) {
+       args = args.concat("--contract_id", contractId);
+    }
+    const result = await this.runCommand(args);
     if (result.exitCode !== 0) {
       return {
         success: false,

--- a/packages/clarity/src/providers/jsonRpc/index.ts
+++ b/packages/clarity/src/providers/jsonRpc/index.ts
@@ -4,7 +4,7 @@ import { Provider } from "../../core/provider";
 export class JsonRpcProvider implements Provider {
   async initialize(): Promise<void> {}
 
-  async checkContract(contractFilePath: string): Promise<CheckResult> {
+  async checkContract(contractFilePath: string, contractId?: string): Promise<CheckResult> {
     return {
       success: false
     };


### PR DESCRIPTION
## Description

Right now, checking a contract `foo.clar` that `contract-call?`'s into contract `bar.clar` will fail because the underlying `clarity-cli` binary does not use `foo.car`'s fully-qualified contract identifier when analyzing it.  The work-around today is to require all `contract-call?`'s to use the fully-qualified contract identifiers, which is somewhat painful for developers.

This PR updates the Clarity provider interface to take an optional `contractId?: string` argument to `checkContract()`.  With proper support from `clarity-cli` (added in this PR here: https://github.com/blockstack/stacks-blockchain/pull/2486), this will enable `checkContract()` to succeed on contracts that invoke other contracts through `contract-call?` via the short-hand notation that elides the address component of the contract identifier.

Additional context here: https://github.com/blockstack/stacks-blockchain/issues/2478.

**NOTE**: This PR is blocked on https://github.com/blockstack/stacks-blockchain/pull/2486, and by extension, blocked on a new release of `clarity-native-bin` that includes it.

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?

No -- the PR should be backwards-compatible, provided it uses a compatible `clarity-native-bin`.

## Are documentation updates required?

Nope -- the new argument is optional, and the `Client` object automatically passes the contract ID for the contract under consideration to the underlying provider's `checkContract()`.

## Testing information

I have so far manually verified that this PR fixes the aforementioned bug in the Stacks blockchain repo.  However, I don't see any existing test coverage for `checkContract` in the `clarity` package.  Please advise on how to proceed.

## Checklist
- [X] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [X] `npm run test` passes
- [X] Changelog is updated
- [X] @lgalabru @zone117x
