### PR TITLE
chore: bump peer dependency version to one matching with latest release

### DIFF
--- a/packages/clarity/package.json
+++ b/packages/clarity/package.json
@@ -34,7 +34,7 @@
     "test": "npm run build && nyc mocha"
   },
   "peerDependencies": {
-    "@blockstack/clarity-native-bin": "^0.1.10-alpha.0"
+    "@blockstack/clarity-native-bin": "^0.3.12"
   },
   "devDependencies": {
     "@blockstack/clarity-native-bin": "^0.3.12",


### PR DESCRIPTION
## Description

Updated obsolete version of peer dependency.
Fixes #171 

As a result new users should not face annoying error during installation.


## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other