### PR TITLE
feat: Improve unwrapping result data

### DIFF
--- a/packages/clarity/src/core/result.ts
+++ b/packages/clarity/src/core/result.ts
@@ -89,29 +89,29 @@ const getWrappedResult = (input: ResultInterface<string, unknown>, r: RegExp) =>
 };
 
 export function unwrapUInt(input: ResultInterface<string, unknown>): number {
-  const match = getWrappedResult(input, /^\(ok\su(\d+)\)$/);
+  const match = getWrappedResult(input, /^(?:\(?ok\s)?u(\d+)\)?$/);
   return parseInt(match);
 }
 
 export function unwrapInt(input: ResultInterface<string, unknown>): number {
-  const match = getWrappedResult(input, /^\(ok\s(\d+)\)$/);
+  const match = getWrappedResult(input, /^(?:\(?ok\s)?(\d+)\)?$/);
   return parseInt(match);
 }
 
 export function unwrapString(input: ResultInterface<string, unknown>, encoding = "hex"): string {
   let match;
   if (encoding === "hex") {
-    match = getWrappedResult(input, /^\(ok\s0x(\w+)\)$/);
+    match = getWrappedResult(input, /^(?:\(?ok\s)?0x(\w+)\)?$/);
   } else if (encoding === "utf8") {
-    match = getWrappedResult(input, /^\(ok\s\u"(.+)\"\)$/);
+    match = getWrappedResult(input, /^(?:\(?ok\s)?u\"(.+)\"\)?$/);
   } else {
-    match = getWrappedResult(input, /^\(ok\s(.+)\)$/);
+    match = getWrappedResult(input, /^(?:\(?ok\s)?(.+)\)?$/);
   }
   return Buffer.from(match, encoding).toString();
 }
 
 export function unwrapBool(input: ResultInterface<string, unknown>): boolean {
-  const match = getWrappedResult(input, /^\(ok\s(true|false)\)$/);
+  const match = getWrappedResult(input, /^(?:\(?ok\s)?(true|false)\)?$/);
   return match === 'true' 
 }
 

--- a/packages/clarity/src/core/result.ts
+++ b/packages/clarity/src/core/result.ts
@@ -103,7 +103,7 @@ export function unwrapString(input: ResultInterface<string, unknown>, encoding =
   if (encoding === "hex") {
     match = getWrappedResult(input, /^\(ok\s0x(\w+)\)$/);
   } else if (encoding === "utf8") {
-    match = getWrappedResult(input, /^\(ok\s\"(.+)\"\)$/);
+    match = getWrappedResult(input, /^\(ok\s\u"(.+)\"\)$/);
   } else {
     match = getWrappedResult(input, /^\(ok\s(.+)\)$/);
   }

--- a/packages/clarity/src/core/result.ts
+++ b/packages/clarity/src/core/result.ts
@@ -110,6 +110,11 @@ export function unwrapString(input: ResultInterface<string, unknown>, encoding =
   return Buffer.from(match, encoding).toString();
 }
 
+export function unwrapBool(input: ResultInterface<string, unknown>): boolean {
+  const match = getWrappedResult(input, /^\(ok\s(true|false)\)$/);
+  return match === 'true' 
+}
+
 export const Result = {
   unwrap: unwrapResult,
   extract: extractResult,
@@ -117,4 +122,5 @@ export const Result = {
   unwrapUInt,
   unwrapInt,
   unwrapString,
+  unwrapBool
 };

--- a/packages/clarity/test/unwrappingDataTypes.ts
+++ b/packages/clarity/test/unwrappingDataTypes.ts
@@ -46,4 +46,22 @@ describe("Unwrapping data types", () => {
     };
     assert.equal(Result.unwrapString(example, "base64"), "hello world");
   });
+
+  it("Unwraps ok boolean (true)", () => {
+    const example:ResultInterface<string, unknown> = {
+      success: true,
+      result: '(ok true)',
+      error: ""
+    };
+    assert.equal(Result.unwrapBool(example), true);
+  });
+
+  it("Unwraps ok boolean (false)", () => {
+    const example:ResultInterface<string, unknown> = {
+      success: true,
+      result: '(ok false)',
+      error: ""
+    };
+    assert.equal(Result.unwrapBool(example), false);
+  });
 })

--- a/packages/clarity/test/unwrappingDataTypes.ts
+++ b/packages/clarity/test/unwrappingDataTypes.ts
@@ -11,10 +11,28 @@ describe("Unwrapping data types", () => {
     assert.equal(Result.unwrapUInt(example), 123);
   });
 
+  it("Unwraps uint ", () => {
+    const example:ResultInterface<string, unknown> = {
+      success: true,
+      result: "u123",
+      error: ""
+    };
+    assert.equal(Result.unwrapUInt(example), 123);
+  });
+
   it("Unwraps ok int", () => {
     const example:ResultInterface<string, unknown> = {
       success: true,
       result: "(ok 123)",
+      error: ""
+    };
+    assert.equal(Result.unwrapInt(example), 123);
+  });
+
+  it("Unwraps int", () => {
+    const example:ResultInterface<string, unknown> = {
+      success: true,
+      result: "123",
       error: ""
     };
     assert.equal(Result.unwrapInt(example), 123);
@@ -29,10 +47,28 @@ describe("Unwrapping data types", () => {
     assert.equal(Result.unwrapString(example), "hello world");
   });
 
+  it("Unwraps hex string", () => {
+    const example:ResultInterface<string, unknown> = {
+      success: true,
+      result: "0x68656c6c6f20776f726c64",
+      error: ""
+    };
+    assert.equal(Result.unwrapString(example), "hello world");
+  });
+
   it("Unwraps ok utf-8 string", () => {
     const example:ResultInterface<string, unknown> = {
       success: true,
       result: `(ok u"\u{d83e}\u{dd84} Stacks")`,
+      error: ""
+    };
+    assert.equal(Result.unwrapString(example, "utf8"), "🦄 Stacks");
+  });
+
+  it("Unwraps utf-8 string", () => {
+    const example:ResultInterface<string, unknown> = {
+      success: true,
+      result: `u"\u{d83e}\u{dd84} Stacks"`,
       error: ""
     };
     assert.equal(Result.unwrapString(example, "utf8"), "🦄 Stacks");
@@ -47,6 +83,15 @@ describe("Unwrapping data types", () => {
     assert.equal(Result.unwrapString(example, "base64"), "hello world");
   });
 
+  it("Unwraps base64 string", () => {
+    const example:ResultInterface<string, unknown> = {
+      success: true,
+      result: '"aGVsbG8gd29ybGQ="',
+      error: ""
+    };
+    assert.equal(Result.unwrapString(example, "base64"), "hello world");
+  });
+
   it("Unwraps ok boolean (true)", () => {
     const example:ResultInterface<string, unknown> = {
       success: true,
@@ -56,10 +101,28 @@ describe("Unwrapping data types", () => {
     assert.equal(Result.unwrapBool(example), true);
   });
 
+  it("Unwraps boolean (true)", () => {
+    const example:ResultInterface<string, unknown> = {
+      success: true,
+      result: 'true',
+      error: ""
+    };
+    assert.equal(Result.unwrapBool(example), true);
+  });
+
   it("Unwraps ok boolean (false)", () => {
     const example:ResultInterface<string, unknown> = {
       success: true,
       result: '(ok false)',
+      error: ""
+    };
+    assert.equal(Result.unwrapBool(example), false);
+  });
+
+  it("Unwraps boolean (false)", () => {
+    const example:ResultInterface<string, unknown> = {
+      success: true,
+      result: 'false',
       error: ""
     };
     assert.equal(Result.unwrapBool(example), false);

--- a/packages/clarity/test/unwrappingDataTypes.ts
+++ b/packages/clarity/test/unwrappingDataTypes.ts
@@ -1,0 +1,49 @@
+import { assert } from "chai"
+import { Result, ResultInterface } from "../src"
+
+describe("Unwrapping data types", () => {
+  it("Unwraps ok uint ", () => {
+    const example:ResultInterface<string, unknown> = {
+      success: true,
+      result: "(ok u123)",
+      error: ""
+    };
+    assert.equal(Result.unwrapUInt(example), 123);
+  });
+
+  it("Unwraps ok int", () => {
+    const example:ResultInterface<string, unknown> = {
+      success: true,
+      result: "(ok 123)",
+      error: ""
+    };
+    assert.equal(Result.unwrapInt(example), 123);
+  });
+
+  it("Unwraps ok hex string", () => {
+    const example:ResultInterface<string, unknown> = {
+      success: true,
+      result: "(ok 0x68656c6c6f20776f726c64)",
+      error: ""
+    };
+    assert.equal(Result.unwrapString(example), "hello world");
+  });
+
+  it("Unwraps ok utf-8 string", () => {
+    const example:ResultInterface<string, unknown> = {
+      success: true,
+      result: `(ok u"\u{d83e}\u{dd84} Stacks")`,
+      error: ""
+    };
+    assert.equal(Result.unwrapString(example, "utf8"), "🦄 Stacks");
+  });
+
+  it("Unwraps ok base64 string", () => {
+    const example:ResultInterface<string, unknown> = {
+      success: true,
+      result: '(ok "aGVsbG8gd29ybGQ=")',
+      error: ""
+    };
+    assert.equal(Result.unwrapString(example, "base64"), "hello world");
+  });
+})


### PR DESCRIPTION
## Description

As a Clarity developer, I would like to be able to unwrap native data types (uint, int, string, bool) returned by read only functions and not wrapped with `(ok value)`.

This PR:
1. fix incorrect regexp pattern used to unwrap utf8 string
2. adds `unwrapBool` function for unwrapping boolean values
3. modifies all regexp patterns to enable parsing data not wrapped with `(ok value)` function
4. adds missing unit tests

## Type of Change
- [x] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
no

## Are documentation updates required?
no

## Testing information

All modifications are covered with unit tests that can be found in `unwrappingDataTypes.ts` file.

## Checklist
- [ ] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated

@zone117x, @lgalabru 