### PR TITLE
fix: new CLI support, proper support for `BLOCKSTACK_CORE_SOURCE_PATH`

### DIFF
--- a/packages/clarity-native-bin/src/directInstall.ts
+++ b/packages/clarity-native-bin/src/directInstall.ts
@@ -13,7 +13,8 @@ export default (async () => {
       process.exit();
     }
   } catch (error) {
-    console.error(`Failed to install clarity-cli native binary: ${error}`);
+    console.error(`Failed to install clarity-cli native binary:`);
+    console.error(error);
     process.exit(1);
   }
 })();

--- a/packages/clarity-native-bin/src/fsUtil.ts
+++ b/packages/clarity-native-bin/src/fsUtil.ts
@@ -73,7 +73,9 @@ export const moveFromPath = (opts: {
   outputFilePath: string;
   inputFilePAth: string;
 }) => {
-  opts.logger.log(`Moving ${opts.inputFilePAth} to ${opts.outputFilePath}`);
-  fs.moveSync(opts.inputFilePAth, opts.outputFilePath);
+  opts.logger.log(`Copying ${opts.inputFilePAth} to ${opts.outputFilePath}`);
+  const dirName = path.dirname(opts.outputFilePath);
+  fs.mkdirpSync(dirName);
+  fs.copyFileSync(opts.inputFilePAth, opts.outputFilePath);
   return true;
 };

--- a/packages/clarity-native-bin/src/index.ts
+++ b/packages/clarity-native-bin/src/index.ts
@@ -81,6 +81,16 @@ export async function installDefaultPath(): Promise<boolean> {
 
   // Check if source git tag/branch was specified using env var
   const sourceOverride = getOverriddenCoreSource();
+
+  if (sourceOverride && sourceOverride.specifier === "path") {
+    logger.log(`Found path source env var ${sourceOverride.specifier}=${sourceOverride.value}`);
+    return moveFromPath({
+      logger,
+      outputFilePath: installPath,
+      inputFilePAth: sourceOverride.value,
+    });
+  }
+
   if (sourceOverride !== false && sourceOverride.specifier !== "path") {
     logger.log(`Found git source env var ${sourceOverride.specifier}=${sourceOverride.value}`);
     fromSource = true;
@@ -113,12 +123,6 @@ export async function installDefaultPath(): Promise<boolean> {
       buildPackage: "blockstack-core",
       gitBranch: versionBranch,
       gitTag: versionTag,
-    });
-  } else if (sourceOverride && sourceOverride.specifier === "path") {
-    success = moveFromPath({
-      logger,
-      outputFilePath: installPath,
-      inputFilePAth: sourceOverride.value,
     });
   } else {
     success = await fetchDistributable({

--- a/packages/clarity/src/providers/clarityBin/index.ts
+++ b/packages/clarity/src/providers/clarityBin/index.ts
@@ -97,7 +97,7 @@ export class NativeClarityBinProvider implements Provider {
         result.stderr
       );
     }
-    if (!result.stdout.endsWith("Database created.")) {
+    if (!result.stdout.includes("Database created.")) {
       throw new ExecutionError(
         `Initialize failed with bad output: ${result.stdout}`,
         result.exitCode,
@@ -136,7 +136,7 @@ export class NativeClarityBinProvider implements Provider {
         result.stderr
       );
     }
-    if (result.stdout !== "Contract initialized!") {
+    if (!result.stdout.includes("Contract initialized!")) {
       throw new ExecutionError(
         `Launch contract failed with bad output: ${result.stdout}`,
         result.exitCode,


### PR DESCRIPTION
When the postInstall script with `BLOCKSTACK_CORE_SOURCE_PATH`, the script did not properly pick up on this ENV var flag on Apple Silicon. This is because the flag for "direct install" was overriding it, and was flagged because there are no native binaries available for download.

I've been using this with some tweaks to `clarity-cli`, so I fixed this to make using my tweaked version easier to install.

It also moves the binary instead of copying it, which makes it easier to re-run the script if needed.

Added later:

The newer version of `clarity-cli` outputs JSON for everything. The native bin provider expected a strict output, so I changed that to support the JSON output. It will still work with the previous version of `clarity-cli`